### PR TITLE
feat(host): PKNT TCP transport, device profiles, HTTP proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env (gitignored; Bun auto-loads it) to route all host-side
+# YouTube traffic — yt-dlp, ffmpeg's https pulls, thumbnail fetches —
+# through a local HTTP proxy. See host/proxy.ts for precedence
+# (--proxy flag > HTTPS_PROXY > HTTP_PROXY > off).
+HTTPS_PROXY=http://127.0.0.1:7897

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .DS_Store
 test/goldens-vita/*.actual.png
 out/
+.env

--- a/app/driver.ts
+++ b/app/driver.ts
@@ -17,7 +17,7 @@
 
 import { getOps, type HostOps } from "@pocketjs/framework/host";
 import { installEffectDriver } from "@pocketjs/framework/effects";
-import { packbitsDecode, PSM } from "../vendor/pocketjs/spec/spec.ts";
+import { packbitsDecode, PSM } from "../vendor/pocketjs/contracts/spec/spec.ts";
 import type { DeviceCmd, HostMsg } from "./protocol.ts";
 
 const HTTP_BASE = "http://127.0.0.1:8620";

--- a/app/protocol.ts
+++ b/app/protocol.ts
@@ -6,9 +6,12 @@
 // Every request carries the app's effect-command id; the reply echoes it, so
 // the app's driver can route deliveries without ordering assumptions.
 
-/** PSP -> host (out.jsonl). */
+/** Device -> host (out.jsonl / PKNT ctrl). */
 export type DeviceCmd =
-  | { t: "hello"; id: number }
+  /** `device` negotiates the stream profile: the host picks plane size,
+   *  frame rate and audio rate per target (host/profiles.ts). Omitted (the
+   *  PSP app predates it) = the tuned PSP defaults. */
+  | { t: "hello"; id: number; device?: { target?: string; density?: number } }
   | { t: "search"; id: number; q: string }
   /** Next batch of the LAST search; replies `results` with only NEW items. */
   | { t: "more"; id: number }

--- a/crates/pocket-youtube-psp/Cargo.toml
+++ b/crates/pocket-youtube-psp/Cargo.toml
@@ -1,7 +1,7 @@
 # pocket-youtube-psp — Pocket YouTube on a real Sony PSP.
 #
 # STANDALONE LONE-BIN CRATE (outside any workspace; cargo-psp requirement,
-# same as vendor/pocketjs/native). Build via `bun run psp` at the repo root.
+# same as vendor/pocketjs/hosts/psp). Build via `bun run psp` at the repo root.
 #
 # Pure 2D composition: the pocketjs-psp host LIBRARY provides everything —
 # the arena allocator trio, QuickJS embedding, the `ui` HostOps surface
@@ -21,4 +21,4 @@ edition = "2021"
 [dependencies]
 psp = { git = "https://github.com/pocket-stack/rust-psp.git", rev = "2cbaf8c9bc72569c76240a1d9743de10731e5f6b", features = ["external-c-heap", "abort-only", "external-global-alloc"] }
 libquickjs-sys = { git = "https://github.com/pocket-stack/quickjs-rs.git", rev = "0fc946fb670c0c29bc0135f510bcb0f595415a61" }
-pocketjs-psp = { path = "../../vendor/pocketjs/native" }
+pocketjs-psp = { path = "../../vendor/pocketjs/hosts/psp" }

--- a/crates/pocket-youtube-psp/build.rs
+++ b/crates/pocket-youtube-psp/build.rs
@@ -1,7 +1,7 @@
 //! Embeds the built viewer into the EBOOT: dist/main.js (NUL-terminated for
 //! JS_Eval, which requires input[len] == '\0'; main.rs evals len - 1) and
 //! dist/main.pak (styles.bin + font atlases + the baked TILESET pyramids).
-//! Same include_str!/include_bytes! pattern as vendor/pocketjs/native/
+//! Same include_str!/include_bytes! pattern as vendor/pocketjs/hosts/psp/
 //! build.rs. POCKETJS_APP_OUTPUT comes from PocketJS HostBuildInputs.
 //! Missing outputs fail the build; scripts/psp.ts always compiles first.
 

--- a/host/cards.ts
+++ b/host/cards.ts
@@ -14,6 +14,7 @@
 // Deterministic given the same inputs — the golden test feeds a fixed RGBA
 // thumb and asserts the row bytes.
 
+import { proxyUrl } from "./proxy.ts";
 import { existsSync } from "node:fs";
 import { parse as parseFont, type Font } from "opentype.js";
 
@@ -342,7 +343,11 @@ function roundCorners(rgba: Uint8Array): void {
  *  Null on any failure — the card falls back to the placeholder panel. */
 export async function fetchThumbRGBA(url: string, tmpDir: string): Promise<Uint8Array | null> {
   try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(8000),
+      // Bun fetch option; explicit beats ambient env for testability.
+      proxy: proxyUrl ?? undefined,
+    });
     if (!res.ok) return null;
     const tmp = `${tmpDir}/thumb-${Bun.hash(url).toString(16)}.img`;
     await Bun.write(tmp, await res.arrayBuffer());

--- a/host/discovery.ts
+++ b/host/discovery.ts
@@ -1,0 +1,27 @@
+// host/discovery.ts — the PKDB UDP beacon (spec.ts "SVC WIRE protocol").
+//
+// Once a second, broadcast "I serve <app> on TCP <port>" — the Vita's
+// supervisor thread listens on WIRE_BEACON_PORT and connects back to the
+// datagram's source address. Broadcast-hostile networks skip this entirely
+// via the device's ux0:data/pocketjs/host.txt override.
+
+import { createSocket } from "node:dgram";
+import { hostname } from "node:os";
+import { WIRE_BEACON_PORT } from "../vendor/pocketjs/contracts/spec/spec.ts";
+import { encodeBeacon } from "./wire.ts";
+
+export function startBeacon(app: string, tcpPort: number): () => void {
+  const socket = createSocket("udp4");
+  const payload = encodeBeacon(tcpPort, app, hostname());
+  let timer: ReturnType<typeof setInterval> | null = null;
+  socket.bind(() => {
+    socket.setBroadcast(true);
+    timer = setInterval(() => {
+      socket.send(payload, WIRE_BEACON_PORT, "255.255.255.255", () => {});
+    }, 1000);
+  });
+  return () => {
+    if (timer) clearInterval(timer);
+    socket.close();
+  };
+}

--- a/host/img.ts
+++ b/host/img.ts
@@ -6,7 +6,7 @@
 // 8888/4444; the youtube host ships everything as PSM_T8 — quantized,
 // PackBits-RLE'd (cards are mostly flat runs), bilinear-flagged.
 
-import { IMG_FLAG_LINEAR, IMG_FLAG_RLE, packbitsEncode, PSM, TEX_MAX_DIM } from "../vendor/pocketjs/spec/spec.ts";
+import { IMG_FLAG_LINEAR, IMG_FLAG_RLE, packbitsEncode, PSM, TEX_MAX_DIM } from "../vendor/pocketjs/contracts/spec/spec.ts";
 import { paletteBytes, quantize } from "./quant.ts";
 
 /** Encode RGBA pixels as a PSM_T8 IMG entry (pow2 dims <= TEX_MAX_DIM). */

--- a/host/media.ts
+++ b/host/media.ts
@@ -15,51 +15,36 @@
 // seek = kill + respawn at the new offset + epoch bump (the device drops its
 // ring positions and re-syncs to the tail).
 //
-// The plane is 256x128 (pow2, spec requirement) PRE-SQUASHED for the PSP's
-// 480x272 stretch: content letterboxed for the final screen aspect, not the
-// texture's own 2:1 — see planeBox().
+// The plane geometry comes from the device profile (profiles.ts): the PSP
+// keeps its tuned 512x128@12 defaults; the Vita negotiates 512x256@24 at
+// hello. Frames are PRE-SQUASHED for the 480x272 logical stretch: content
+// letterboxed for the final screen aspect, not the texture's own aspect —
+// see planeBox(). Output lands in a StreamSink (sink.ts): the PSP's ring
+// FILE or the Vita's TCP slot push, same geometry either way.
 
-import { unlinkSync } from "node:fs";
-import type { StreamGeometry } from "./ring.ts";
-import { StreamWriter } from "./ring.ts";
+import { ffmpegProxyArgs, proxyEnv } from "./proxy.ts";
 import { quantize, paletteBytes } from "./quant.ts";
+import type { StreamSink } from "./sink.ts";
 import type { ResolvedStream } from "./yt.ts";
-
-// 512x128: horizontal resolution lands near 1:1 on the 480-wide screen
-// (sharpness lives in horizontal detail); vertical stays the 2.1x stretch.
-// 12 fps x 65 KB slots + audio ≈ 0.87 MB/s — inside the usbhostfs budget
-// the device pumps at IO_BUDGET per tick (native/src/vid.rs).
-export const PLANE_W = 512;
-export const PLANE_H = 128;
-export const FPS = 12;
-export const SAMPLE_RATE = 22050;
-export const CHUNK_FRAMES = 2048;
-
-export const GEOMETRY: Omit<StreamGeometry, "totalFrames"> = {
-  w: PLANE_W,
-  h: PLANE_H,
-  fpsNum: FPS,
-  fpsDen: 1,
-  slotCount: 8,
-  sampleRate: SAMPLE_RATE,
-  channels: 2,
-  chunkFrames: CHUNK_FRAMES,
-  chunkCount: 64,
-};
 
 /**
  * Content box inside the plane for a source aspect ratio: the plane is
  * stretched to the full 480x272 screen, so the box must letterbox in SCREEN
- * space and then map back into plane texels (x: *256/480, y: *128/272).
- * For 16:9 that lands at 256x127 — half-pixel bars, effectively full plane.
+ * space and then map back into plane texels. For a 16:9 source the error vs
+ * a true screen-space letterbox is sub-pixel — effectively full plane.
  */
-export function planeBox(srcW: number, srcH: number): { w: number; h: number } {
+export function planeBox(
+  srcW: number,
+  srcH: number,
+  planeW: number,
+  planeH: number,
+): { w: number; h: number } {
   const screenW = 480;
   const screenH = 272;
   const fit = Math.min(screenW / srcW, screenH / srcH);
-  const w = Math.round(((srcW * fit) / screenW) * PLANE_W);
-  const h = Math.round(((srcH * fit) / screenH) * PLANE_H);
-  return { w: Math.min(PLANE_W, Math.max(16, w & ~1)), h: Math.min(PLANE_H, Math.max(16, h & ~1)) };
+  const w = Math.round(((srcW * fit) / screenW) * planeW);
+  const h = Math.round(((srcH * fit) / screenH) * planeH);
+  return { w: Math.min(planeW, Math.max(16, w & ~1)), h: Math.min(planeH, Math.max(16, h & ~1)) };
 }
 
 export interface SessionEvents {
@@ -69,10 +54,9 @@ export interface SessionEvents {
 
 export class PlaySession {
   readonly stream: ResolvedStream;
-  readonly file: string;
   /** svc-relative path the app passes to videoOpen. */
   readonly relPath: string;
-  private writer: StreamWriter;
+  private writer: StreamSink;
   private video: Bun.Subprocess | null = null;
   private audio: Bun.Subprocess | null = null;
   private baseFrame = 0;
@@ -83,31 +67,32 @@ export class PlaySession {
   private closed = false;
   private events: SessionEvents;
 
-  constructor(stream: ResolvedStream, svcDir: string, relPath: string, events: SessionEvents = {}) {
+  constructor(stream: ResolvedStream, sink: StreamSink, events: SessionEvents = {}) {
     this.stream = stream;
-    this.relPath = relPath;
-    this.file = `${svcDir}/${relPath}`;
+    this.relPath = sink.relPath;
     this.events = events;
-    this.writer = new StreamWriter(this.file, {
-      ...GEOMETRY,
-      totalFrames: Math.max(0, Math.round(stream.durationS * FPS)),
-    });
+    this.writer = sink;
     this.spawnAt(0);
   }
 
+  private get fps(): number {
+    return this.writer.geo.fpsNum / this.writer.geo.fpsDen;
+  }
+
   get positionBase(): number {
-    return this.baseFrame / FPS;
+    return this.baseFrame / this.fps;
   }
 
   private spawnAt(seconds: number): void {
-    this.baseFrame = Math.round(seconds * FPS);
-    this.baseSample = Math.round(seconds * SAMPLE_RATE);
+    const geo = this.writer.geo;
+    this.baseFrame = Math.round(seconds * this.fps);
+    this.baseSample = Math.round(seconds * geo.sampleRate);
     const seek = seconds > 0 ? ["-ss", seconds.toFixed(2)] : [];
     // Letterbox in SCREEN space, not texture space: the plane's texels are
     // anamorphic (the 512x128 texture stretches to 480x272), so fitting the
     // source into the raw texture box would pillarbox 16:9 into a strip.
     // planeBox maps the true screen-space fit back into texels.
-    const box = planeBox(this.stream.width || 16, this.stream.height || 9);
+    const box = planeBox(this.stream.width || 16, this.stream.height || 9, geo.w, geo.h);
     this.video = Bun.spawn(
       [
         "ffmpeg",
@@ -115,13 +100,14 @@ export class PlaySession {
         "-loglevel",
         "error",
         "-re",
+        ...ffmpegProxyArgs(),
         ...seek,
         "-i",
         this.stream.url,
         "-vf",
         // lanczos: the plane is anamorphic (wide texels), so every scrap of
         // horizontal acutance from the 720p source survives to the screen.
-        `fps=${FPS},scale=${box.w}:${box.h}:flags=lanczos,pad=${PLANE_W}:${PLANE_H}:(ow-iw)/2:(oh-ih)/2:black`,
+        `fps=${this.fps},scale=${box.w}:${box.h}:flags=lanczos,pad=${geo.w}:${geo.h}:(ow-iw)/2:(oh-ih)/2:black`,
         "-an",
         "-f",
         "rawvideo",
@@ -129,7 +115,7 @@ export class PlaySession {
         "rgb24",
         "pipe:1",
       ],
-      { stdout: "pipe", stderr: "ignore" },
+      { stdout: "pipe", stderr: "ignore", env: { ...process.env, ...proxyEnv() } },
     );
     this.audio = Bun.spawn(
       [
@@ -138,6 +124,7 @@ export class PlaySession {
         "-loglevel",
         "error",
         "-re",
+        ...ffmpegProxyArgs(),
         ...seek,
         "-i",
         this.stream.url,
@@ -145,12 +132,12 @@ export class PlaySession {
         "-ac",
         "2",
         "-ar",
-        String(SAMPLE_RATE),
+        String(geo.sampleRate),
         "-f",
         "s16le",
         "pipe:1",
       ],
-      { stdout: "pipe", stderr: "ignore" },
+      { stdout: "pipe", stderr: "ignore", env: { ...process.env, ...proxyEnv() } },
     );
     void this.pumpVideo(this.video, this.baseFrame);
     void this.pumpAudio(this.audio, this.baseSample);
@@ -161,8 +148,9 @@ export class PlaySession {
    *  16:9 source the error vs. a true screen-space letterbox is <1% (see
    *  planeBox); acceptable against a second scale pass. */
   private async pumpVideo(proc: Bun.Subprocess, baseFrame: number): Promise<void> {
-    const frameBytes = PLANE_W * PLANE_H * 3;
-    const rgba = new Uint8Array(PLANE_W * PLANE_H * 4);
+    const { w: planeW, h: planeH } = this.writer.geo;
+    const frameBytes = planeW * planeH * 3;
+    const rgba = new Uint8Array(planeW * planeH * 4);
     let pending = new Uint8Array(0);
     let index = 0;
     const stdout = proc.stdout;
@@ -174,13 +162,13 @@ export class PlaySession {
       while (buf.length - off >= frameBytes) {
         const rgb = buf.subarray(off, off + frameBytes);
         off += frameBytes;
-        for (let i = 0; i < PLANE_W * PLANE_H; i++) {
+        for (let i = 0; i < planeW * planeH; i++) {
           rgba[i * 4] = rgb[i * 3];
           rgba[i * 4 + 1] = rgb[i * 3 + 1];
           rgba[i * 4 + 2] = rgb[i * 3 + 2];
           rgba[i * 4 + 3] = 255;
         }
-        const q = quantize(rgba, PLANE_W, PLANE_H);
+        const q = quantize(rgba, planeW, planeH);
         if (this.closed || proc !== this.video) return;
         this.writer.writeFrame(baseFrame + index, paletteBytes(q.palette), q.indices);
         index++;
@@ -195,7 +183,8 @@ export class PlaySession {
   }
 
   private async pumpAudio(proc: Bun.Subprocess, baseSample: number): Promise<void> {
-    const chunkSamples = CHUNK_FRAMES * 2;
+    const geo = this.writer.geo;
+    const chunkSamples = geo.chunkFrames * geo.channels;
     let pending = new Uint8Array(0);
     let frames = 0;
     const stdout = proc.stdout;
@@ -211,7 +200,7 @@ export class PlaySession {
         const pcm = new Int16Array(bytes.buffer, 0, chunkSamples);
         if (this.closed || proc !== this.audio) return;
         this.writer.writeAudio(baseSample + frames, pcm);
-        frames += CHUNK_FRAMES;
+        frames += geo.chunkFrames;
       }
       pending = buf.slice();
     }
@@ -243,7 +232,7 @@ export class PlaySession {
    *  cleanly (kill + respawn + epoch bump); reuse it. */
   resume(): void {
     if (!this.paused || this.closed) return;
-    this.seek(this.framesWritten / FPS);
+    this.seek(this.framesWritten / this.fps);
   }
 
   get isPaused(): boolean {
@@ -267,18 +256,13 @@ export class PlaySession {
     this.audio = null;
   }
 
-  /** Stop and delete the ring file (a new session writes a fresh file — the
-   *  device holds no fd into this one once the app videoClose()s). */
+  /** Stop and close the sink (the file sink deletes its ring file — the
+   *  device holds no fd into it once the app videoClose()s). */
   close(): void {
     if (this.closed) return;
     this.closed = true;
     this.killProcs();
     this.writer.close();
-    try {
-      unlinkSync(this.file);
-    } catch {
-      // already gone — fine
-    }
   }
 }
 

--- a/host/profiles.ts
+++ b/host/profiles.ts
@@ -1,0 +1,58 @@
+// host/profiles.ts — per-device stream quality, negotiated at hello.
+//
+// The .pkst geometry was born tuned for the PSP's USB budget. The Vita has
+// 802.11n and 512 MB of RAM, so its hello carries `device: { target }` and
+// the host picks a richer pipeline. The mailbox transport never sends a
+// device field -> PSP profile -> the file-ring output stays byte-identical.
+//
+// Vita plane: TEX_MAX_DIM = 512 caps the texture at 512x256 (PSP GE shares
+// the constant, so no per-host exception). 512x256 CLUT8 @ 24 fps + 44.1 kHz
+// stereo ≈ 3.3 MB/s raw; the TCP sink's latest-only backpressure adapts the
+// effective frame rate to what the WiFi actually carries, audio always wins.
+
+import type { StreamGeometry } from "./ring.ts";
+
+export interface DeviceProfile {
+  name: "psp" | "vita";
+  planeW: number;
+  planeH: number;
+  fps: number;
+  sampleRate: number;
+  geometry: Omit<StreamGeometry, "totalFrames">;
+}
+
+function profile(
+  name: DeviceProfile["name"],
+  planeW: number,
+  planeH: number,
+  fps: number,
+  sampleRate: number,
+): DeviceProfile {
+  return {
+    name,
+    planeW,
+    planeH,
+    fps,
+    sampleRate,
+    geometry: {
+      w: planeW,
+      h: planeH,
+      fpsNum: fps,
+      fpsDen: 1,
+      slotCount: 8,
+      sampleRate,
+      channels: 2,
+      chunkFrames: 2048,
+      chunkCount: 64,
+    },
+  };
+}
+
+/** The tuned USB defaults — unchanged, the PSP contract. */
+export const PSP_PROFILE = profile("psp", 512, 128, 12, 22050);
+/** The WiFi profile: full-height plane, double rate, native 44.1 kHz. */
+export const VITA_PROFILE = profile("vita", 512, 256, 24, 44100);
+
+export function profileFor(device?: { target?: string }): DeviceProfile {
+  return device?.target === "vita" ? VITA_PROFILE : PSP_PROFILE;
+}

--- a/host/proxy.ts
+++ b/host/proxy.ts
@@ -1,0 +1,38 @@
+// host/proxy.ts — one resolution point for the outbound HTTP proxy.
+//
+// All real network IO happens on the Mac (yt-dlp, ffmpeg's https pulls, the
+// thumbnail fetch); the device never talks to YouTube. Routing that traffic
+// through a local proxy (Clash-style, e.g. http://127.0.0.1:7897) is
+// therefore purely host-side. Precedence: --proxy flag > HTTPS_PROXY >
+// HTTP_PROXY > off. Bun auto-loads .env from the project root — copy
+// .env.example to .env for a persistent default; nothing is hardcoded.
+
+function cliFlag(name: string): string | undefined {
+  const argv = process.argv;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === name) return argv[i + 1];
+    if (argv[i]?.startsWith(`${name}=`)) return argv[i].slice(name.length + 1);
+  }
+  return undefined;
+}
+
+export const proxyUrl: string | null =
+  cliFlag("--proxy") ?? process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY ?? null;
+
+/** yt-dlp: an explicit flag beats env-var ambiguity. */
+export function ytDlpProxyArgs(): string[] {
+  return proxyUrl ? ["--proxy", proxyUrl] : [];
+}
+
+/** ffmpeg: googlevideo URLs are https, and ffmpeg's env handling only
+ *  covers plain http — pass the protocol AVOption explicitly, BEFORE -i,
+ *  so https CONNECT-tunnels through the proxy. */
+export function ffmpegProxyArgs(): string[] {
+  return proxyUrl ? ["-http_proxy", proxyUrl] : [];
+}
+
+/** Belt and suspenders for ffmpeg subprocess env. */
+export function proxyEnv(): Record<string, string> {
+  if (!proxyUrl) return {};
+  return { http_proxy: proxyUrl, https_proxy: proxyUrl };
+}

--- a/host/ring.ts
+++ b/host/ring.ts
@@ -24,7 +24,7 @@ import {
   STREAM_VRING_MAGIC,
   STREAM_VRING_OFF,
   TEX_MAX_DIM,
-} from "../vendor/pocketjs/spec/spec.ts";
+} from "../vendor/pocketjs/contracts/spec/spec.ts";
 
 export interface StreamGeometry {
   /** Plane dims — pow2 <= TEX_MAX_DIM (the plane texture IS the frame). */

--- a/host/serve.ts
+++ b/host/serve.ts
@@ -1,32 +1,38 @@
-// demos/youtube/host/serve.ts — the Pocket YouTube macOS host service.
+// host/serve.ts — the Pocket YouTube macOS host service.
 //
-//   bun demos/youtube/host/serve.ts --dir <usbhostfs-root>   (PSP over USB)
-//   bun demos/youtube/host/serve.ts --dir ~/ppsspp-memstick  (PPSSPP)
-//   bun demos/youtube/host/serve.ts --http 8620              (browser dev)
+//   bun host/serve.ts --dir <usbhostfs-root>    (PSP over USB)
+//   bun host/serve.ts --dir ~/ppsspp-memstick   (PPSSPP)
+//   bun host/serve.ts --http 8620               (browser dev)
+//   bun host/serve.ts --tcp [8622]              (Vita over WiFi + beacon)
+//   ... --proxy http://127.0.0.1:7897           (route YouTube via a proxy)
 //
-// The PSP has no WiFi in this design: the Mac owns YouTube's protocol layer
-// (yt-dlp), decode (ffmpeg) and pixels (quant.ts), and shares the results
-// through the usbhostfs directory the PSP already mounts under PSPLINK —
-// control as JSON lines (spec.ts SVC), search cards as IMG side files,
-// playback as a .pkst ring stream (media.ts). Point --dir at whatever
-// directory the device sees as host0:
-//   bun run hw youtube        -> native/target/mipsel-sony-psp/<profile>
-//   bun psplink               -> dist/psplink            (the default here)
-//
-// --http additionally serves the same dispatch over localhost for the
-// browser host (the app's driver falls back to fetch when the svc ops are
-// absent): POST /cmd -> reply JSON, GET /events?since= -> push queue,
-// GET /svc/<rel> -> side-file bytes.
+// The devices own no network: the Mac owns YouTube's protocol layer
+// (yt-dlp), decode (ffmpeg) and pixels (quant.ts), and ships the results
+// over whichever transport the device speaks —
+//   PSP:  the usbhostfs directory PSPLINK mounts as host0: (JSON-line
+//         mailbox + IMG side files + a .pkst ring FILE),
+//   Vita: one PKNT TCP connection (the same lines/files/ring as framed
+//         messages; transports/tcp.ts) discovered via the UDP beacon,
+//   dev:  localhost HTTP for the browser host.
+// All three share one dispatch; per-connection state lives in a
+// TransportCtx (the hello handshake picks the device's stream profile).
 
 import { appendFileSync, existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { WIRE_PORT } from "../vendor/pocketjs/contracts/spec/spec.ts";
 import type { DeviceCmd, HostMsg, ResultItem } from "../app/protocol.ts";
 import { CARD_H, CARD_W, fetchThumbRGBA, renderCard } from "./cards.ts";
+import { startBeacon } from "./discovery.ts";
 import { encodeImgT8 } from "./img.ts";
-import { FPS, PlaySession } from "./media.ts";
+import { PlaySession } from "./media.ts";
+import { profileFor, PSP_PROFILE, type DeviceProfile } from "./profiles.ts";
+import { proxyUrl } from "./proxy.ts";
+import { FileRingSink, type StreamSink } from "./sink.ts";
+import { startTcpTransport, type TcpConnection } from "./transports/tcp.ts";
 import { resolve as resolveVideo, search, thumbnailUrl } from "./yt.ts";
 
 const ROOT = new URL("..", import.meta.url).pathname;
+const APP = "youtube";
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -34,19 +40,29 @@ const ROOT = new URL("..", import.meta.url).pathname;
 
 let dir = ROOT + "dist/psplink";
 let httpPort: number | null = null;
+let tcpPort: number | null = null;
 const argv = process.argv.slice(2);
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === "--dir") dir = resolvePath(argv[++i] ?? "");
   else if (argv[i]?.startsWith("--dir=")) dir = resolvePath(argv[i].slice("--dir=".length));
   else if (argv[i] === "--http") httpPort = Number(argv[++i] ?? 8620);
   else if (argv[i]?.startsWith("--http=")) httpPort = Number(argv[i].slice("--http=".length));
-  else {
-    console.error("usage: bun demos/youtube/host/serve.ts [--dir <usbhostfs-root>] [--http <port>]");
+  else if (argv[i] === "--tcp") {
+    const next = argv[i + 1];
+    tcpPort = next && /^\d+$/.test(next) ? Number(argv[++i]) : WIRE_PORT;
+  } else if (argv[i]?.startsWith("--tcp=")) tcpPort = Number(argv[i].slice("--tcp=".length));
+  else if (argv[i] === "--proxy") i++; // consumed by proxy.ts
+  else if (argv[i]?.startsWith("--proxy=")) {
+    // consumed by proxy.ts
+  } else {
+    console.error(
+      "usage: bun host/serve.ts [--dir <usbhostfs-root>] [--http <port>] [--tcp [port]] [--proxy <url>]",
+    );
     process.exit(1);
   }
 }
 
-const svcDir = `${dir}/pocket-svc/youtube`;
+const svcDir = `${dir}/pocket-svc/${APP}`;
 mkdirSync(`${svcDir}/thumbs`, { recursive: true });
 mkdirSync(`${svcDir}/media`, { recursive: true });
 // Fresh session: the device seeks in.jsonl to EOF at svcOpen, we tail
@@ -55,21 +71,43 @@ writeFileSync(`${svcDir}/in.jsonl`, "");
 writeFileSync(`${svcDir}/out.jsonl`, "");
 writeFileSync(`${svcDir}/enable`, "");
 console.log(`pocket-youtube host: svc dir ${svcDir}`);
+if (proxyUrl) console.log(`pocket-youtube host: proxying YouTube via ${proxyUrl}`);
 
 // ---------------------------------------------------------------------------
-// State + replies
+// Transport context — what dispatch needs from whichever wire it serves
 // ---------------------------------------------------------------------------
+
+interface TransportCtx {
+  /** Stream/plane profile, negotiated by the hello's device field. */
+  profile: DeviceProfile;
+  /** Deliver a side file (card IMG) so a later loadImgFile resolves. */
+  pushFile(rel: string, bytes: Uint8Array): void;
+  /** Create the play sink the session writes into. */
+  makeSink(rel: string, totalFrames: number): StreamSink;
+  /** Push a host->device message outside a request/reply pair. */
+  post(msg: HostMsg): void;
+}
 
 let session: PlaySession | null = null;
 let playSerial = 0;
 /** Push queue for the HTTP transport (mailbox pushes append directly). */
 const httpEvents: HostMsg[] = [];
 
-function post(msg: HostMsg): void {
-  appendFileSync(`${svcDir}/in.jsonl`, JSON.stringify(msg) + "\n");
-  if (httpPort !== null) httpEvents.push(msg);
-  if (msg.t !== "state") console.log("->", JSON.stringify(msg).slice(0, 140));
-}
+/** The shared-filesystem context (PSP mailbox + browser HTTP). */
+const fileCtx: TransportCtx = {
+  profile: PSP_PROFILE,
+  pushFile(rel, bytes) {
+    writeFileSync(`${svcDir}/${rel}`, bytes);
+  },
+  makeSink(rel, totalFrames) {
+    return new FileRingSink(svcDir, rel, { ...this.profile.geometry, totalFrames });
+  },
+  post(msg) {
+    appendFileSync(`${svcDir}/in.jsonl`, JSON.stringify(msg) + "\n");
+    if (httpPort !== null) httpEvents.push(msg);
+    if (msg.t !== "state") console.log("->", JSON.stringify(msg).slice(0, 140));
+  },
+};
 
 function fail(id: number, e: unknown): HostMsg {
   const message = e instanceof Error ? e.message : String(e);
@@ -78,14 +116,17 @@ function fail(id: number, e: unknown): HostMsg {
 }
 
 // ---------------------------------------------------------------------------
-// Command dispatch (shared by mailbox and HTTP)
+// Command dispatch (shared by every transport)
 // ---------------------------------------------------------------------------
 
 const SEARCH_PAGE = 12;
 let lastQuery = "";
 let lastCount = 0;
 
-async function renderItems(found: Awaited<ReturnType<typeof search>>): Promise<ResultItem[]> {
+async function renderItems(
+  found: Awaited<ReturnType<typeof search>>,
+  ctx: TransportCtx,
+): Promise<ResultItem[]> {
   return Promise.all(
     found.map(async (f) => {
       const thumb = await fetchThumbRGBA(thumbnailUrl(f.videoId), `${svcDir}/thumbs`);
@@ -97,16 +138,18 @@ async function renderItems(found: Awaited<ReturnType<typeof search>>): Promise<R
         thumbRgba: thumb,
       });
       const rel = `thumbs/${f.videoId}.img`;
-      writeFileSync(`${svcDir}/${rel}`, encodeImgT8(rgba, CARD_W, CARD_H));
+      // Delivered BEFORE the results line that references it (implicit on
+      // the shared filesystem, explicit frame ordering on TCP).
+      ctx.pushFile(rel, encodeImgT8(rgba, CARD_W, CARD_H));
       return { ...f, card: rel };
     }),
   );
 }
 
-async function doSearch(id: number, q: string): Promise<HostMsg> {
+async function doSearch(id: number, q: string, ctx: TransportCtx): Promise<HostMsg> {
   console.log(`search: "${q}"`);
   const found = await search(q, SEARCH_PAGE);
-  const items = await renderItems(found);
+  const items = await renderItems(found, ctx);
   lastQuery = q;
   lastCount = items.length;
   console.log(`  ${items.length} result(s), cards rendered`);
@@ -116,25 +159,27 @@ async function doSearch(id: number, q: string): Promise<HostMsg> {
 /** Next page of the last search: ytsearch has no offset, so re-fetch a
  *  longer prefix and slice off what the device already has. Replies only
  *  the NEW items (empty = end of results). */
-async function doMore(id: number): Promise<HostMsg> {
+async function doMore(id: number, ctx: TransportCtx): Promise<HostMsg> {
   if (!lastQuery) return { t: "results", id, items: [] };
   console.log(`more: "${lastQuery}" past ${lastCount}`);
   const found = await search(lastQuery, lastCount + SEARCH_PAGE);
   const fresh = found.slice(lastCount);
-  const items = await renderItems(fresh);
+  const items = await renderItems(fresh, ctx);
   lastCount += items.length;
   console.log(`  +${items.length} result(s)`);
   return { t: "results", id, items };
 }
 
-async function doPlay(id: number, videoId: string): Promise<HostMsg> {
-  console.log(`play: ${videoId}`);
+async function doPlay(id: number, videoId: string, ctx: TransportCtx): Promise<HostMsg> {
+  console.log(`play: ${videoId} (${ctx.profile.name} profile)`);
   session?.close();
   session = null;
   const stream = await resolveVideo(videoId);
   const rel = `media/play-${++playSerial}.pkst`;
-  session = new PlaySession(stream, svcDir, rel, {
-    onEnd: () => post({ t: "ended" }),
+  const totalFrames = Math.max(0, Math.round(stream.durationS * ctx.profile.fps));
+  const sink = ctx.makeSink(rel, totalFrames);
+  session = new PlaySession(stream, sink, {
+    onEnd: () => ctx.post({ t: "ended" }),
   });
   console.log(`  streaming "${stream.title}" (${stream.durationS}s) -> ${rel}`);
   return {
@@ -143,47 +188,55 @@ async function doPlay(id: number, videoId: string): Promise<HostMsg> {
     videoId,
     title: stream.title,
     durationS: stream.durationS,
-    fps: FPS,
+    fps: ctx.profile.fps,
     stream: rel,
     position: 0,
   };
 }
 
-async function dispatch(cmd: DeviceCmd): Promise<HostMsg | null> {
+async function dispatch(cmd: DeviceCmd, ctx: TransportCtx): Promise<HostMsg | null> {
   switch (cmd.t) {
     case "hello":
+      ctx.profile = profileFor(cmd.device);
+      if (ctx.profile.name !== "psp") {
+        console.log(`hello: device=${cmd.device?.target} -> ${ctx.profile.name} profile`);
+      }
       return { t: "ready", id: cmd.id };
     case "search":
       try {
-        return await doSearch(cmd.id, cmd.q);
+        return await doSearch(cmd.id, cmd.q, ctx);
       } catch (e) {
         return fail(cmd.id, e);
       }
     case "more":
       try {
-        return await doMore(cmd.id);
+        return await doMore(cmd.id, ctx);
       } catch (e) {
         return fail(cmd.id, e);
       }
     case "play":
       try {
-        return await doPlay(cmd.id, cmd.videoId);
+        return await doPlay(cmd.id, cmd.videoId, ctx);
       } catch (e) {
         return fail(cmd.id, e);
       }
     case "pause":
       session?.pause();
+      if (session) console.log(`pause @ ${session.positionBase.toFixed(1)}s`);
       return { t: "state", id: cmd.id, playing: false, position: session?.positionBase ?? 0 };
     case "resume":
       session?.resume();
+      if (session) console.log(`resume @ ${session.positionBase.toFixed(1)}s`);
       return { t: "state", id: cmd.id, playing: true, position: session?.positionBase ?? 0 };
     case "seek":
       if (session) {
         session.seek(cmd.to);
+        console.log(`seek -> ${session.positionBase.toFixed(1)}s`);
         return { t: "state", id: cmd.id, playing: true, position: session.positionBase };
       }
       return { t: "state", id: cmd.id, playing: false, position: 0 };
     case "stop":
+      if (session) console.log(`stop @ ${session.positionBase.toFixed(1)}s`);
       session?.close();
       session = null;
       return { t: "state", id: cmd.id, playing: false, position: 0 };
@@ -191,7 +244,7 @@ async function dispatch(cmd: DeviceCmd): Promise<HostMsg | null> {
 }
 
 // ---------------------------------------------------------------------------
-// Mailbox tail (same offset/truncation handling as scripts/devtools-bridge.ts)
+// Mailbox tail (same offset/truncation handling as the devtools bridge)
 // ---------------------------------------------------------------------------
 
 let tailOff = 0;
@@ -222,8 +275,8 @@ async function pollMailbox(): Promise<void> {
       console.error("bad line from device:", line.slice(0, 120));
       continue;
     }
-    const reply = await dispatch(cmd);
-    if (reply) post(reply);
+    const reply = await dispatch(cmd, fileCtx);
+    if (reply) fileCtx.post(reply);
   }
 }
 
@@ -235,6 +288,51 @@ setInterval(() => {
     polling = false;
   });
 }, 100);
+
+// ---------------------------------------------------------------------------
+// TCP transport (Vita over WiFi) + discovery beacon
+// ---------------------------------------------------------------------------
+
+if (tcpPort !== null) {
+  const ctxFor = new Map<TcpConnection, TransportCtx>();
+  const transport = startTcpTransport({
+    port: tcpPort,
+    app: APP,
+    onConnect(conn) {
+      ctxFor.set(conn, {
+        profile: PSP_PROFILE, // until the hello negotiates otherwise
+        pushFile: (rel, bytes) => conn.pushFile(rel, bytes),
+        makeSink(rel, totalFrames) {
+          return conn.makeSink(rel, { ...this.profile.geometry, totalFrames });
+        },
+        post(msg) {
+          conn.sendLine(JSON.stringify(msg));
+          if (msg.t !== "state") console.log("->", JSON.stringify(msg).slice(0, 140));
+        },
+      });
+    },
+    onDisconnect(conn) {
+      ctxFor.delete(conn);
+    },
+    onLine(conn, line) {
+      const ctx = ctxFor.get(conn);
+      if (!ctx) return;
+      let cmd: DeviceCmd;
+      try {
+        cmd = JSON.parse(line) as DeviceCmd;
+      } catch {
+        console.error("bad line from device:", line.slice(0, 120));
+        return;
+      }
+      void dispatch(cmd, ctx).then((reply) => {
+        if (reply) ctx.post(reply);
+      });
+    },
+  });
+  const stopBeacon = startBeacon(APP, transport.port());
+  console.log(`pocket-youtube host: tcp on :${transport.port()} (beacon broadcasting)`);
+  process.on("exit", stopBeacon);
+}
 
 // ---------------------------------------------------------------------------
 // HTTP transport (browser-host dev; same dispatch)
@@ -252,7 +350,7 @@ if (httpPort !== null) {
       if (req.method === "OPTIONS") return new Response(null, { headers: CORS });
       if (req.method === "POST" && url.pathname === "/cmd") {
         const cmd = (await req.json()) as DeviceCmd;
-        const reply = await dispatch(cmd);
+        const reply = await dispatch(cmd, fileCtx);
         return Response.json(reply, { headers: CORS });
       }
       if (url.pathname === "/events") {
@@ -275,7 +373,7 @@ if (httpPort !== null) {
   console.log(`pocket-youtube host: http on http://127.0.0.1:${httpPort}`);
 }
 
-console.log("pocket-youtube host: waiting for the device (svcOpen probes the enable file)");
+console.log("pocket-youtube host: waiting for the device (svcOpen probes the enable file / TCP)");
 
 process.on("SIGINT", () => {
   session?.close();

--- a/host/sink.ts
+++ b/host/sink.ts
@@ -1,0 +1,65 @@
+// host/sink.ts — the seam between the play pipeline and its transport.
+//
+// media.ts produces frames/chunks/marks; a StreamSink decides where they
+// land: the PSP writes a preallocated .pkst ring FILE over usbhostfs
+// (FileRingSink = the existing StreamWriter plus file lifecycle), the Vita
+// receives the same ring as PKNT wire messages over TCP and reconstructs a
+// byte-identical file IMAGE in RAM (engine/core/src/stream_rx.rs). Same
+// geometry, same publish order, one golden format.
+
+import { unlinkSync } from "node:fs";
+import type { StreamGeometry } from "./ring.ts";
+import { StreamWriter } from "./ring.ts";
+
+export interface StreamSink {
+  readonly geo: StreamGeometry;
+  /** svc-relative path the app passes to videoOpen. */
+  readonly relPath: string;
+  writeFrame(frameIndex: number, palette: Uint8Array, indices: Uint8Array): void;
+  writeAudio(startFrame: number, pcm: Int16Array): void;
+  bumpEpoch(): void;
+  markEnded(): void;
+  close(): void;
+}
+
+/** The PSP path: StreamWriter into `${svcDir}/${relPath}`, file deleted on
+ *  close (a new session writes a fresh file). Byte-identical to the
+ *  pre-sink host. */
+export class FileRingSink implements StreamSink {
+  readonly geo: StreamGeometry;
+  readonly relPath: string;
+  private readonly file: string;
+  private readonly writer: StreamWriter;
+
+  constructor(svcDir: string, relPath: string, geo: StreamGeometry) {
+    this.geo = geo;
+    this.relPath = relPath;
+    this.file = `${svcDir}/${relPath}`;
+    this.writer = new StreamWriter(this.file, geo);
+  }
+
+  writeFrame(frameIndex: number, palette: Uint8Array, indices: Uint8Array): void {
+    this.writer.writeFrame(frameIndex, palette, indices);
+  }
+
+  writeAudio(startFrame: number, pcm: Int16Array): void {
+    this.writer.writeAudio(startFrame, pcm);
+  }
+
+  bumpEpoch(): void {
+    this.writer.bumpEpoch();
+  }
+
+  markEnded(): void {
+    this.writer.markEnded();
+  }
+
+  close(): void {
+    this.writer.close();
+    try {
+      unlinkSync(this.file);
+    } catch {
+      // already gone — fine
+    }
+  }
+}

--- a/host/transports/tcp.ts
+++ b/host/transports/tcp.ts
@@ -1,0 +1,251 @@
+// host/transports/tcp.ts — the PKNT TCP transport (Vita over WiFi).
+//
+// One connection carries everything, and its ORDERING is the contract: the
+// streamOpen precedes the JSON line announcing the stream, and every card's
+// FILE push precedes the results line referencing it — the same guarantees
+// the PSP's shared-filesystem transport provides implicitly, made explicit.
+//
+// TcpStreamSink applies latest-only backpressure to video: when the socket
+// has not drained the previous slot, the queued slot is REPLACED by the
+// newer one (frameIndex gaps are legal per the .pkst spec — "the host may
+// skip indices"), so the effective frame rate adapts itself to what the
+// WiFi actually carries. Audio chunks always queue — audio wins.
+
+import { createServer, type Server, type Socket } from "node:net";
+import { packbitsEncode } from "../../vendor/pocketjs/contracts/spec/spec.ts";
+import type { StreamGeometry } from "../ring.ts";
+import type { StreamSink } from "../sink.ts";
+import {
+  drainFrames,
+  encodeAudioChunk,
+  encodeFrame,
+  encodeHelloAck,
+  encodePathPayload,
+  encodeStreamMark,
+  encodeVideoSlot,
+  headerBlock,
+  parseHello,
+  WIRE_MSG,
+} from "../wire.ts";
+
+const PING_EVERY_MS = 2000;
+const SILENCE_DROP_MS = 10_000;
+
+/** What a live device connection offers the dispatch layer. */
+export interface TcpConnection {
+  /** The negotiated app id from the handshake. */
+  readonly app: string;
+  readonly remote: string;
+  sendLine(json: string): void;
+  pushFile(rel: string, bytes: Uint8Array): void;
+  makeSink(rel: string, geo: StreamGeometry): StreamSink;
+  close(): void;
+}
+
+export interface TcpTransportOptions {
+  port: number;
+  app: string;
+  /** A ctrl line arrived from the device. */
+  onLine(conn: TcpConnection, line: string): void;
+  onConnect?(conn: TcpConnection): void;
+  onDisconnect?(conn: TcpConnection): void;
+}
+
+export interface TcpTransport {
+  server: Server;
+  /** The bound port (useful with port 0 in tests). */
+  port(): number;
+  close(): void;
+}
+
+class Connection implements TcpConnection {
+  readonly app: string;
+  readonly remote: string;
+  private readonly socket: Socket;
+  /** Latest-only staging for a video slot the socket has not accepted yet. */
+  private pendingSlot: Uint8Array | null = null;
+  private canWrite = true;
+
+  constructor(socket: Socket, app: string) {
+    this.socket = socket;
+    this.app = app;
+    this.remote = `${socket.remoteAddress}:${socket.remotePort}`;
+    socket.on("drain", () => {
+      this.canWrite = true;
+      if (this.pendingSlot) {
+        const slot = this.pendingSlot;
+        this.pendingSlot = null;
+        this.send(slot);
+      }
+    });
+  }
+
+  /** Raw frame write (sink + transport internals). */
+  send(frame: Uint8Array): void {
+    if (this.socket.destroyed) return;
+    this.canWrite = this.socket.write(frame);
+  }
+
+  sendLine(json: string): void {
+    this.send(encodeFrame(WIRE_MSG.ctrl, 0, new TextEncoder().encode(json)));
+  }
+
+  pushFile(rel: string, bytes: Uint8Array): void {
+    this.send(encodeFrame(WIRE_MSG.file, 0, encodePathPayload(rel, bytes)));
+  }
+
+  ping(token: number): void {
+    const payload = new Uint8Array(4);
+    new DataView(payload.buffer).setUint32(0, token, true);
+    this.send(encodeFrame(WIRE_MSG.ping, 0, payload));
+  }
+
+  /** Queue a video slot with latest-only backpressure. */
+  offerSlot(frame: Uint8Array): void {
+    if (!this.canWrite) {
+      this.pendingSlot = frame; // replace whatever was waiting
+      return;
+    }
+    this.send(frame);
+  }
+
+  makeSink(rel: string, geo: StreamGeometry): StreamSink {
+    return new TcpStreamSink(this, rel, geo);
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
+export class TcpStreamSink implements StreamSink {
+  readonly geo: StreamGeometry;
+  readonly relPath: string;
+  private readonly conn: Connection;
+  private videoSeq = 0;
+  private audioSeq = 0;
+  private epoch = 0;
+  private ended = false;
+
+  constructor(conn: Connection, relPath: string, geo: StreamGeometry) {
+    this.conn = conn;
+    this.relPath = relPath;
+    this.geo = geo;
+    // Every streamOpen is a full ring reset device-side.
+    this.conn.send(encodeFrame(WIRE_MSG.streamOpen, 0, encodePathPayload(relPath, headerBlock(geo))));
+  }
+
+  writeFrame(frameIndex: number, palette: Uint8Array, indices: Uint8Array): void {
+    const seq = ++this.videoSeq;
+    // RLE only when it actually shrinks the payload (flat scenes, bars).
+    const rle = packbitsEncode(indices);
+    const useRle = rle.length < indices.length;
+    const payload = encodeVideoSlot(
+      seq,
+      frameIndex,
+      this.geo.w,
+      this.geo.h,
+      palette,
+      useRle ? rle : indices,
+      useRle,
+    );
+    this.conn.offerSlot(encodeFrame(WIRE_MSG.videoSlot, useRle ? 1 : 0, payload));
+  }
+
+  writeAudio(startFrame: number, pcm: Int16Array): void {
+    const seq = ++this.audioSeq;
+    this.conn.send(encodeFrame(WIRE_MSG.audioChunk, 0, encodeAudioChunk(seq, startFrame, pcm)));
+  }
+
+  bumpEpoch(): void {
+    this.epoch++;
+    this.conn.send(encodeFrame(WIRE_MSG.streamMark, 0, encodeStreamMark(this.epoch, this.ended)));
+  }
+
+  markEnded(): void {
+    this.ended = true;
+    this.conn.send(encodeFrame(WIRE_MSG.streamMark, 0, encodeStreamMark(this.epoch, true)));
+  }
+
+  close(): void {
+    this.conn.send(encodeFrame(WIRE_MSG.streamClose, 0, new Uint8Array(0)));
+  }
+}
+
+export function startTcpTransport(opts: TcpTransportOptions): TcpTransport {
+  const server = createServer((socket) => {
+    socket.setNoDelay(true);
+    let buf = new Uint8Array(0);
+    let conn: Connection | null = null;
+    let lastRx = Date.now();
+    let pingToken = 0;
+
+    const pinger = setInterval(() => {
+      if (Date.now() - lastRx > SILENCE_DROP_MS) {
+        socket.destroy();
+        return;
+      }
+      conn?.ping(++pingToken);
+    }, PING_EVERY_MS);
+
+    socket.on("data", (chunk: Buffer) => {
+      lastRx = Date.now();
+      const merged = new Uint8Array(buf.length + chunk.length);
+      merged.set(buf, 0);
+      merged.set(chunk, buf.length);
+      buf = merged;
+
+      if (!conn) {
+        const hello = parseHello(buf);
+        if (hello === null) return; // incomplete
+        if (hello === "bad" || hello.app !== opts.app) {
+          socket.destroy();
+          return;
+        }
+        buf = buf.slice(hello.consumed);
+        socket.write(encodeHelloAck());
+        conn = new Connection(socket, hello.app);
+        console.log(`tcp: device connected from ${conn.remote}`);
+        opts.onConnect?.(conn);
+        // fall through: the same chunk may already carry frames
+      }
+
+      let frames;
+      try {
+        ({ frames, rest: buf } = drainFrames(buf));
+      } catch {
+        socket.destroy(); // oversize frame: unrecoverable inside a stream
+        return;
+      }
+      for (const frame of frames) {
+        if (frame.kind === WIRE_MSG.ctrl) {
+          const line = new TextDecoder().decode(frame.payload);
+          opts.onLine(conn, line);
+        }
+        // pong (and unknown types): rx timestamp already refreshed above.
+      }
+    });
+
+    socket.on("close", () => {
+      clearInterval(pinger);
+      if (conn) {
+        console.log(`tcp: device ${conn.remote} disconnected`);
+        opts.onDisconnect?.(conn);
+      }
+    });
+    socket.on("error", () => {
+      // close follows; nothing to do
+    });
+  });
+  server.listen(opts.port);
+  return {
+    server,
+    port() {
+      const addr = server.address();
+      return typeof addr === "object" && addr ? addr.port : opts.port;
+    },
+    close() {
+      server.close();
+    },
+  };
+}

--- a/host/wire.ts
+++ b/host/wire.ts
@@ -1,0 +1,177 @@
+// host/wire.ts — the TS twin of engine/core/src/wire.rs (spec.ts "SVC WIRE
+// protocol"): frame encode/parse, the beacon datagram, and the verbatim
+// 96-byte .pkst header block a streamOpen carries. Constants come from the
+// vendored spec so the two sides cannot drift.
+
+import {
+  STREAM_ARING_MAGIC,
+  STREAM_ARING_OFF,
+  STREAM_HEADER_BLOCK_SIZE,
+  STREAM_MAGIC,
+  STREAM_VERSION,
+  STREAM_VRING_MAGIC,
+  STREAM_VRING_OFF,
+  WIRE_BEACON_MAGIC,
+  WIRE_HEADER_SIZE,
+  WIRE_MAGIC,
+  WIRE_MAX_PAYLOAD,
+  WIRE_MSG,
+  WIRE_VERSION,
+} from "../vendor/pocketjs/contracts/spec/spec.ts";
+import { slotSizeOf, type StreamGeometry } from "./ring.ts";
+
+export { WIRE_MSG };
+
+export function encodeFrame(kind: number, flags: number, payload: Uint8Array): Uint8Array {
+  if (payload.length > WIRE_MAX_PAYLOAD) {
+    throw new Error(`wire: payload ${payload.length} exceeds WIRE_MAX_PAYLOAD`);
+  }
+  const out = new Uint8Array(WIRE_HEADER_SIZE + payload.length);
+  const dv = new DataView(out.buffer);
+  dv.setUint8(0, kind);
+  dv.setUint8(1, flags);
+  dv.setUint32(4, payload.length, true);
+  out.set(payload, WIRE_HEADER_SIZE);
+  return out;
+}
+
+export interface WireFrame {
+  kind: number;
+  flags: number;
+  payload: Uint8Array;
+}
+
+/** Incremental frame parser over a growing buffer. Returns the parsed
+ *  frames and the unconsumed tail. Throws on an oversize length (the
+ *  connection must close — resync inside a byte stream is impossible). */
+export function drainFrames(buf: Uint8Array): { frames: WireFrame[]; rest: Uint8Array } {
+  const frames: WireFrame[] = [];
+  let off = 0;
+  while (buf.length - off >= WIRE_HEADER_SIZE) {
+    const dv = new DataView(buf.buffer, buf.byteOffset + off);
+    const len = dv.getUint32(4, true);
+    if (len > WIRE_MAX_PAYLOAD) throw new Error("wire: oversize frame");
+    if (buf.length - off < WIRE_HEADER_SIZE + len) break;
+    frames.push({
+      kind: dv.getUint8(0),
+      flags: dv.getUint8(1),
+      payload: buf.slice(off + WIRE_HEADER_SIZE, off + WIRE_HEADER_SIZE + len),
+    });
+    off += WIRE_HEADER_SIZE + len;
+  }
+  return { frames, rest: buf.slice(off) };
+}
+
+/** Device hello: magic · version · reserved · appLen · app. Returns the app
+ *  id and consumed byte count, or null while incomplete / on mismatch. */
+export function parseHello(buf: Uint8Array): { app: string; consumed: number } | null | "bad" {
+  if (buf.length < 7) return null;
+  const dv = new DataView(buf.buffer, buf.byteOffset);
+  if (dv.getUint32(0, true) !== WIRE_MAGIC || dv.getUint8(4) !== WIRE_VERSION) return "bad";
+  const appLen = dv.getUint8(6);
+  if (appLen === 0 || appLen > 64) return "bad";
+  if (buf.length < 7 + appLen) return null;
+  return { app: new TextDecoder().decode(buf.slice(7, 7 + appLen)), consumed: 7 + appLen };
+}
+
+export function encodeHelloAck(): Uint8Array {
+  const out = new Uint8Array(8);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, WIRE_MAGIC, true);
+  dv.setUint8(4, WIRE_VERSION);
+  return out;
+}
+
+/** file / streamOpen payload prefix: u16 pathLen · path · body. */
+export function encodePathPayload(path: string, body: Uint8Array): Uint8Array {
+  const pathBytes = new TextEncoder().encode(path);
+  const out = new Uint8Array(2 + pathBytes.length + body.length);
+  new DataView(out.buffer).setUint16(0, pathBytes.length, true);
+  out.set(pathBytes, 2);
+  out.set(body, 2 + pathBytes.length);
+  return out;
+}
+
+/** The verbatim 96-byte .pkst header block for a fresh stream (cursors 0,
+ *  epoch 0) — StreamWriter.writeHeaders' layout, buffer edition. */
+export function headerBlock(geo: StreamGeometry): Uint8Array {
+  const b = new Uint8Array(STREAM_HEADER_BLOCK_SIZE);
+  const dv = new DataView(b.buffer);
+  const slotSize = slotSizeOf(geo);
+  const videoOff = STREAM_HEADER_BLOCK_SIZE;
+  const audioOff = videoOff + geo.slotCount * slotSize;
+  dv.setUint32(0, STREAM_MAGIC, true);
+  dv.setUint16(4, STREAM_VERSION, true);
+  dv.setUint32(12, videoOff, true);
+  dv.setUint32(16, audioOff, true);
+  dv.setUint32(STREAM_VRING_OFF, STREAM_VRING_MAGIC, true);
+  dv.setUint16(STREAM_VRING_OFF + 4, geo.w, true);
+  dv.setUint16(STREAM_VRING_OFF + 6, geo.h, true);
+  dv.setUint16(STREAM_VRING_OFF + 8, geo.fpsNum, true);
+  dv.setUint16(STREAM_VRING_OFF + 10, geo.fpsDen, true);
+  dv.setUint32(STREAM_VRING_OFF + 12, geo.slotCount, true);
+  dv.setUint32(STREAM_VRING_OFF + 16, slotSize, true);
+  dv.setUint32(STREAM_VRING_OFF + 24, geo.totalFrames, true);
+  dv.setUint32(STREAM_ARING_OFF, STREAM_ARING_MAGIC, true);
+  dv.setUint32(STREAM_ARING_OFF + 4, geo.sampleRate, true);
+  dv.setUint16(STREAM_ARING_OFF + 8, geo.channels, true);
+  dv.setUint32(STREAM_ARING_OFF + 12, geo.chunkFrames, true);
+  dv.setUint32(STREAM_ARING_OFF + 16, geo.chunkCount, true);
+  return b;
+}
+
+/** videoSlot payload: seq · frameIndex · w · h · flags · rsv · palette ·
+ *  indices (raw, or PackBits when the flag says so). */
+export function encodeVideoSlot(
+  seq: number,
+  frameIndex: number,
+  w: number,
+  h: number,
+  palette: Uint8Array,
+  indices: Uint8Array,
+  rle: boolean,
+): Uint8Array {
+  const out = new Uint8Array(16 + 1024 + indices.length);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, seq, true);
+  dv.setUint32(4, frameIndex, true);
+  dv.setUint16(8, w, true);
+  dv.setUint16(10, h, true);
+  dv.setUint16(12, rle ? 1 : 0, true);
+  out.set(palette, 16);
+  out.set(indices, 16 + 1024);
+  return out;
+}
+
+export function encodeAudioChunk(seq: number, startFrame: number, pcm: Int16Array): Uint8Array {
+  const out = new Uint8Array(8 + pcm.byteLength);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, seq, true);
+  dv.setUint32(4, startFrame, true);
+  out.set(new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength), 8);
+  return out;
+}
+
+export function encodeStreamMark(epoch: number, ended: boolean): Uint8Array {
+  const out = new Uint8Array(8);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, epoch, true);
+  dv.setUint16(4, ended ? 1 : 0, true);
+  return out;
+}
+
+/** The PKDB discovery datagram. */
+export function encodeBeacon(tcpPort: number, app: string, name: string): Uint8Array {
+  const appBytes = new TextEncoder().encode(app);
+  const nameBytes = new TextEncoder().encode(name.slice(0, 32));
+  const out = new Uint8Array(8 + 1 + appBytes.length + 1 + nameBytes.length);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, WIRE_BEACON_MAGIC, true);
+  dv.setUint8(4, WIRE_VERSION);
+  dv.setUint16(6, tcpPort, true);
+  dv.setUint8(8, appBytes.length);
+  out.set(appBytes, 9);
+  dv.setUint8(9 + appBytes.length, nameBytes.length);
+  out.set(nameBytes, 10 + appBytes.length);
+  return out;
+}

--- a/host/yt.ts
+++ b/host/yt.ts
@@ -9,6 +9,8 @@
 // The runner is injectable so tests exercise the parsing without a network
 // (memory: never .sh — Bun.spawn only).
 
+import { ytDlpProxyArgs } from "./proxy.ts";
+
 export interface SearchItem {
   videoId: string;
   title: string;
@@ -34,7 +36,11 @@ export interface ResolvedStream {
 export type Runner = (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
 
 export const spawnRunner: Runner = async (args) => {
-  const proc = Bun.spawn(["yt-dlp", ...args], { stdout: "pipe", stderr: "pipe" });
+  // The proxy rides an explicit flag (beats env-var ambiguity inside yt-dlp).
+  const proc = Bun.spawn(["yt-dlp", ...ytDlpProxyArgs(), ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const [stdout, stderr, code] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "bootstrap": "bun vendor/pocketjs/scripts/bootstrap.ts",
+    "bootstrap": "bun vendor/pocketjs/tools/bootstrap.ts",
     "setup": "git submodule update --init && cd vendor/pocketjs && bun install && cd ../.. && mkdir -p node_modules && ln -sfn ../vendor/pocketjs/node_modules/solid-js node_modules/solid-js && ln -sfn ../vendor/pocketjs/node_modules/opentype.js node_modules/opentype.js && ln -sfn ../vendor/pocketjs/node_modules/@napi-rs node_modules/@napi-rs && ln -sfn ../vendor/pocketjs/node_modules/bun-types node_modules/bun-types && ln -sfn ../vendor/pocketjs/node_modules/typescript node_modules/typescript",
-    "build": "bun vendor/pocketjs/scripts/build.ts app/main.tsx --outdir=dist",
-    "check:platforms": "bun vendor/pocketjs/scripts/pocket.ts check --target psp",
+    "build": "bun vendor/pocketjs/tools/build.ts app/main.tsx --outdir=dist",
+    "check:platforms": "bun vendor/pocketjs/tools/pocket.ts check --target psp",
     "psp": "bun scripts/psp.ts",
     "serve": "bun host/serve.ts",
+    "serve:vita": "bun host/serve.ts --tcp",
+    "serve:proxy": "bun host/serve.ts --tcp --proxy http://127.0.0.1:7897",
     "test": "bun test test/host.test.ts && bun test --conditions=browser test/sim.test.ts",
     "cover": "bun tools/gen-cover.ts"
   }

--- a/scripts/pocket-plan.ts
+++ b/scripts/pocket-plan.ts
@@ -15,7 +15,7 @@ export async function compilePocketTarget(
   const manifestPath = `${projectRoot}pocket.json`;
   const planPath = `${projectRoot}.pocket/${target}/plan.json`;
 
-  await $`bun vendor/pocketjs/scripts/pocket.ts compile --target ${target} --manifest ${manifestPath} --project-root ${projectRoot} --outdir ${outputDirectory}`
+  await $`bun vendor/pocketjs/tools/pocket.ts compile --target ${target} --manifest ${manifestPath} --project-root ${projectRoot} --outdir ${outputDirectory}`
     .cwd(projectRoot);
 
   const plan: unknown = await Bun.file(planPath).json();

--- a/scripts/psp.ts
+++ b/scripts/psp.ts
@@ -3,7 +3,7 @@
 //   bun scripts/psp.ts        # debug profile (opt-level 3 override below)
 //   bun scripts/psp.ts -r     # release
 //
-// The cross env matches vendor/pocketjs/scripts/psp.ts: Homebrew LLVM first
+// The cross env matches vendor/pocketjs/tools/psp.ts: Homebrew LLVM first
 // on PATH, TARGET_CFLAGS for the
 // MIPS clang C builds, llvm-ar/ranlib for MIPS archives (Apple ar drops
 // them), RUST_PSP_TARGET at the vendored target json, RUST_PSP_ABORT_ONLY=1.
@@ -12,7 +12,7 @@
 
 import { $ } from "bun";
 import { existsSync } from "node:fs";
-import { resolvePspBuildToolchain } from "../vendor/pocketjs/scripts/psp-toolchain.ts";
+import { resolvePspBuildToolchain } from "../vendor/pocketjs/tools/psp-toolchain.ts";
 import {
   compilePocketTarget,
   nativePlanEnvironment,
@@ -42,7 +42,7 @@ const llvm = toolchain.llvmBin;
 const env = {
   ...toolchain.environment,
   // Benign +abicalls(newlib) vs +noabicalls(rust-psp) linker warnings stay
-  // suppressed, matching vendor/pocketjs/scripts/psp.ts.
+  // suppressed, matching vendor/pocketjs/tools/psp.ts.
   RUSTFLAGS: "-A linker-messages -A unexpected-cfgs -A unstable-name-collisions",
   CRATE_CC_NO_DEFAULTS: "1",
   TARGET_CC: "clang",
@@ -55,7 +55,7 @@ const env = {
   // CRITICAL: archive MIPS objects with llvm-ar (Apple ar drops them -> undefined JS_*).
   AR_mipsel_sony_psp: `${llvm}/llvm-ar`,
   RANLIB_mipsel_sony_psp: `${llvm}/llvm-ranlib`,
-  RUST_PSP_TARGET: `${repo}vendor/pocketjs/native/targets/mipsel-sony-psp.json`,
+  RUST_PSP_TARGET: `${repo}vendor/pocketjs/hosts/psp/targets/mipsel-sony-psp.json`,
   // panic-abort EBOOTs: no panic_unwind/libunwind in build-std.
   RUST_PSP_ABORT_ONLY: "1",
   // Keep PSP dev builds fast (opt-level 0 is unusably slow on hardware).

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,12 +1,12 @@
 // test/harness.ts — boot the Pocket YouTube bundle against PocketJS's wasm
-// core, exactly like vendor/pocketjs/host-sim/sim.ts does for in-repo demos,
+// core, exactly like vendor/pocketjs/hosts/sim/sim.ts does for in-repo demos,
 // but with this project's dist/ and plan-compiled bundle. The pure helpers
 // (scriptToMasks, treeHasText, fnv1a, ScriptEvent) are imported from the
 // vendored harness — only the boot path is project-specific.
 
 import { existsSync } from "node:fs";
-import { createWasmUi } from "../vendor/pocketjs/host-web/wasm-ops.js";
-import type { EffectEvent } from "../vendor/pocketjs/host-sim/sim.ts";
+import { createWasmUi } from "../vendor/pocketjs/hosts/web/wasm-ops.js";
+import type { EffectEvent } from "../vendor/pocketjs/hosts/sim/sim.ts";
 import { compilePocketTarget } from "../scripts/pocket-plan.ts";
 
 export {
@@ -15,11 +15,11 @@ export {
   treeHasText,
   type EffectEvent,
   type ScriptEvent,
-} from "../vendor/pocketjs/host-sim/sim.ts";
+} from "../vendor/pocketjs/hosts/sim/sim.ts";
 
 const ROOT = new URL("..", import.meta.url).pathname;
 const DIST = `${ROOT}dist/`;
-const WASM = `${ROOT}vendor/pocketjs/host-web/pocketjs.wasm`;
+const WASM = `${ROOT}vendor/pocketjs/hosts/web/pocketjs.wasm`;
 const TICKS_PER_SECOND = 60;
 
 export interface SimWorld {
@@ -42,7 +42,7 @@ export async function bootWorld(
   extraGlobals?: Record<string, unknown>,
 ): Promise<SimWorld> {
   if (!existsSync(WASM)) {
-    const p = Bun.spawnSync(["bun", "scripts/wasm.ts"], {
+    const p = Bun.spawnSync(["bun", "tools/wasm.ts"], {
       cwd: `${ROOT}vendor/pocketjs`,
       stdout: "inherit",
       stderr: "inherit",

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -8,7 +8,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, test } from "bun:test";
-import { packbitsDecode, PSM } from "../vendor/pocketjs/spec/spec.ts";
+import { packbitsDecode, PSM } from "../vendor/pocketjs/contracts/spec/spec.ts";
 import { paletteBytes, quantize } from "../host/quant.ts";
 import { encodeImgT8 } from "../host/img.ts";
 import { readStream, StreamWriter, type StreamGeometry } from "../host/ring.ts";

--- a/test/sim.test.ts
+++ b/test/sim.test.ts
@@ -20,10 +20,10 @@ import {
   treeHasText,
   type ScriptEvent,
 } from "./harness.ts";
-import { BTN, SCREEN_H, SCREEN_W } from "../vendor/pocketjs/spec/spec.ts";
-import { layoutRows, OSK_H, OSK_LAYERS, OSK_PAD, OSK_GAP, OSK_ROW_H } from "../vendor/pocketjs/src/osk-layout.ts";
-import { __packTouch } from "../vendor/pocketjs/src/touch.ts";
-import { OskScripter } from "../vendor/pocketjs/test/osk-script.ts";
+import { BTN, SCREEN_H, SCREEN_W } from "../vendor/pocketjs/contracts/spec/spec.ts";
+import { layoutRows, OSK_H, OSK_LAYERS, OSK_PAD, OSK_GAP, OSK_ROW_H } from "../vendor/pocketjs/framework/src/osk-layout.ts";
+import { __packTouch } from "../vendor/pocketjs/framework/src/touch.ts";
+import { OskScripter } from "../vendor/pocketjs/tests/osk-script.ts";
 import type { HostMsg, ResultItem } from "../app/protocol.ts";
 
 const ITEMS: ResultItem[] = [

--- a/test/tcp.test.ts
+++ b/test/tcp.test.ts
@@ -1,0 +1,317 @@
+// test/tcp.test.ts — the PKNT TCP transport, protocol-level.
+//
+// A fake device (plain Bun.connect socket) drives the real transport:
+// handshake, ctrl round-trip, FILE-before-results ordering, and the
+// sink-equivalence proof — the same writeFrame/writeAudio/mark sequence
+// driven into a FileRingSink and a TcpStreamSink must produce the same
+// .pkst image, where the TCP side is reassembled by a TS mirror of
+// engine/core/src/stream_rx.rs (payload first, latestSeq after).
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { connect, type Socket } from "node:net";
+import {
+  packbitsDecode,
+  STREAM_ARING_OFF,
+  STREAM_HEADER_BLOCK_SIZE,
+  STREAM_SLOT_HEADER_SIZE,
+  STREAM_VRING_OFF,
+  WIRE_MAGIC,
+  WIRE_VERSION,
+} from "../vendor/pocketjs/contracts/spec/spec.ts";
+import { FileRingSink } from "../host/sink.ts";
+import { chunkSizeOf, slotSizeOf, type StreamGeometry } from "../host/ring.ts";
+import { drainFrames, encodeFrame, WIRE_MSG, type WireFrame } from "../host/wire.ts";
+import { encodeBeacon } from "../host/wire.ts";
+import { startTcpTransport, type TcpConnection } from "../host/transports/tcp.ts";
+
+const GEO: StreamGeometry = {
+  w: 32,
+  h: 16,
+  fpsNum: 24,
+  fpsDen: 1,
+  slotCount: 2,
+  sampleRate: 44100,
+  channels: 2,
+  chunkFrames: 64,
+  chunkCount: 2,
+  totalFrames: 0,
+};
+
+const tmp = mkdtempSync(`${tmpdir()}/pkyt-tcp-`);
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+// ---------------------------------------------------------------------------
+// A minimal fake device
+// ---------------------------------------------------------------------------
+
+interface FakeDevice {
+  socket: Socket;
+  frames: WireFrame[];
+  /** Resolves when at least `n` frames have arrived. */
+  waitFrames(n: number): Promise<void>;
+  sendLine(json: string): void;
+  close(): void;
+}
+
+function hello(app: string): Uint8Array {
+  const bytes = new TextEncoder().encode(app);
+  const out = new Uint8Array(7 + bytes.length);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, WIRE_MAGIC, true);
+  dv.setUint8(4, WIRE_VERSION);
+  dv.setUint8(6, bytes.length);
+  out.set(bytes, 7);
+  return out;
+}
+
+function fakeDevice(port: number, app = "youtube"): Promise<FakeDevice> {
+  return new Promise((resolveDevice, reject) => {
+    const socket = connect({ port, host: "127.0.0.1" }, () => {
+      socket.write(hello(app));
+    });
+    socket.setNoDelay(true);
+    const frames: WireFrame[] = [];
+    const waiters: { n: number; done: () => void }[] = [];
+    let buf = new Uint8Array(0);
+    let acked = false;
+    socket.on("data", (chunk: Buffer) => {
+      const merged = new Uint8Array(buf.length + chunk.length);
+      merged.set(buf, 0);
+      merged.set(chunk, buf.length);
+      buf = merged;
+      if (!acked) {
+        if (buf.length < 8) return;
+        const dv = new DataView(buf.buffer, buf.byteOffset);
+        if (dv.getUint32(0, true) !== WIRE_MAGIC) {
+          reject(new Error("bad ack"));
+          return;
+        }
+        buf = buf.slice(8);
+        acked = true;
+        resolveDevice(device);
+      }
+      const drained = drainFrames(buf);
+      buf = drained.rest;
+      frames.push(...drained.frames);
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (frames.length >= waiters[i].n) {
+          waiters[i].done();
+          waiters.splice(i, 1);
+        }
+      }
+    });
+    socket.on("error", reject);
+    socket.on("close", () => {
+      // A clean pre-ack close (server rejected the handshake) must settle.
+      if (!acked) reject(new Error("closed before handshake ack"));
+    });
+    const device: FakeDevice = {
+      socket,
+      frames,
+      waitFrames(n) {
+        if (frames.length >= n) return Promise.resolve();
+        return new Promise((done) => waiters.push({ n, done }));
+      },
+      sendLine(json) {
+        socket.write(encodeFrame(WIRE_MSG.ctrl, 0, new TextEncoder().encode(json)));
+      },
+      close() {
+        socket.destroy();
+      },
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// A TS mirror of stream_rx.rs: apply wire messages into a .pkst image
+// ---------------------------------------------------------------------------
+
+function reassemble(frames: WireFrame[]): Uint8Array {
+  let buf: Uint8Array | null = null;
+  let geoW = 0;
+  let geoH = 0;
+  let chunkBytes = 0;
+  let slotSize = 0;
+  let chunkSize = 0;
+  let videoOff = 0;
+  let audioOff = 0;
+  const dv = () => new DataView(buf!.buffer);
+  for (const frame of frames) {
+    const p = frame.payload;
+    const pdv = new DataView(p.buffer, p.byteOffset);
+    switch (frame.kind) {
+      case WIRE_MSG.streamOpen: {
+        const pathLen = pdv.getUint16(0, true);
+        const block = p.slice(2 + pathLen);
+        const bdv = new DataView(block.buffer);
+        geoW = bdv.getUint16(STREAM_VRING_OFF + 4, true);
+        geoH = bdv.getUint16(STREAM_VRING_OFF + 6, true);
+        const slotCount = bdv.getUint32(STREAM_VRING_OFF + 12, true);
+        slotSize = bdv.getUint32(STREAM_VRING_OFF + 16, true);
+        const chunkFrames = bdv.getUint32(STREAM_ARING_OFF + 12, true);
+        const chunkCount = bdv.getUint32(STREAM_ARING_OFF + 16, true);
+        const channels = bdv.getUint16(STREAM_ARING_OFF + 8, true);
+        chunkBytes = chunkFrames * channels * 2;
+        chunkSize = 16 + chunkBytes;
+        videoOff = bdv.getUint32(12, true);
+        audioOff = bdv.getUint32(16, true);
+        buf = new Uint8Array(Math.max(videoOff + slotCount * slotSize, audioOff + chunkCount * chunkSize));
+        buf.set(block, 0);
+        break;
+      }
+      case WIRE_MSG.videoSlot: {
+        const seq = pdv.getUint32(0, true);
+        const frameIndex = pdv.getUint32(4, true);
+        const rle = (pdv.getUint16(12, true) & 1) !== 0;
+        const palette = p.slice(16, 16 + 1024);
+        const indicesRaw = p.slice(16 + 1024);
+        const px = geoW * geoH;
+        const indices = rle ? packbitsDecode(indicesRaw, px)! : indicesRaw;
+        const off = videoOff + ((seq - 1) % 2) * slotSize;
+        const sdv = dv();
+        buf!.set(palette, off + STREAM_SLOT_HEADER_SIZE);
+        buf!.set(indices, off + STREAM_SLOT_HEADER_SIZE + 1024);
+        sdv.setUint32(off, seq, true);
+        sdv.setUint32(off + 4, frameIndex, true);
+        sdv.setUint16(off + 8, geoW, true);
+        sdv.setUint16(off + 10, geoH, true);
+        sdv.setUint32(STREAM_VRING_OFF + 20, seq, true); // publish after payload
+        break;
+      }
+      case WIRE_MSG.audioChunk: {
+        const seq = pdv.getUint32(0, true);
+        const startFrame = pdv.getUint32(4, true);
+        const off = audioOff + ((seq - 1) % 2) * chunkSize;
+        buf!.set(p.slice(8), off + 16);
+        const sdv = dv();
+        sdv.setUint32(off, seq, true);
+        sdv.setUint32(off + 4, startFrame, true);
+        sdv.setUint32(STREAM_ARING_OFF + 20, seq, true);
+        break;
+      }
+      case WIRE_MSG.streamMark: {
+        const sdv = dv();
+        sdv.setUint32(8, pdv.getUint32(0, true), true);
+        if (pdv.getUint16(4, true) & 1) sdv.setUint16(6, 1, true);
+        break;
+      }
+    }
+  }
+  return buf ?? new Uint8Array(0);
+}
+
+// ---------------------------------------------------------------------------
+
+describe("tcp transport", () => {
+  test("handshake + ctrl round trip; FILE frames precede the results line", async () => {
+    const lines: string[] = [];
+    let conn: TcpConnection | null = null;
+    const transport = startTcpTransport({
+      port: 0,
+      app: "youtube",
+      onConnect(c) {
+        conn = c;
+      },
+      onLine(c, line) {
+        lines.push(line);
+        // A search-ish reply: two card pushes, THEN the results line.
+        c.pushFile("thumbs/a.img", new Uint8Array([1, 2, 3]));
+        c.pushFile("thumbs/b.img", new Uint8Array([4, 5]));
+        c.sendLine(JSON.stringify({ t: "results", id: 1, items: [] }));
+      },
+    });
+    const device = await fakeDevice(transport.port());
+    expect(conn).not.toBeNull();
+    device.sendLine(JSON.stringify({ t: "search", id: 1, q: "test" }));
+    await device.waitFrames(3);
+    expect(lines).toEqual(['{"t":"search","id":1,"q":"test"}']);
+    const kinds = device.frames.map((f) => f.kind);
+    const fileIdx = [kinds.indexOf(WIRE_MSG.file), kinds.lastIndexOf(WIRE_MSG.file)];
+    const ctrlIdx = kinds.indexOf(WIRE_MSG.ctrl);
+    expect(fileIdx[0]).toBeGreaterThanOrEqual(0);
+    expect(ctrlIdx).toBeGreaterThan(fileIdx[1]); // ordering IS the contract
+    device.close();
+    transport.close();
+  });
+
+  test("rejects a handshake for the wrong app", async () => {
+    const transport = startTcpTransport({ port: 0, app: "youtube", onLine() {} });
+    await expect(
+      (async () => {
+        const device = await fakeDevice(transport.port(), "not-youtube");
+        device.close();
+      })(),
+    ).rejects.toThrow();
+    transport.close();
+  });
+
+  test("sink equivalence: TCP frames reassemble the exact FileRingSink image", async () => {
+    let conn: TcpConnection | null = null;
+    const transport = startTcpTransport({
+      port: 0,
+      app: "youtube",
+      onConnect(c) {
+        conn = c;
+      },
+      onLine() {},
+    });
+    const device = await fakeDevice(transport.port());
+    expect(conn).not.toBeNull();
+
+    // Drive the SAME sequence into both sinks. Slot 3 laps slot 1; pcm and
+    // pixel data are deterministic patterns; frame 2 is RLE-friendly.
+    const paletteFor = (s: number) => new Uint8Array(1024).map((_, i) => (i + s) & 0xff);
+    const pixelsFor = (s: number) =>
+      s === 2
+        ? new Uint8Array(GEO.w * GEO.h).fill(7) // compresses -> exercises RLE
+        : new Uint8Array(GEO.w * GEO.h).map((_, i) => (i * s) & 0xff);
+    const pcmFor = (s: number) =>
+      new Int16Array(GEO.chunkFrames * GEO.channels).map((_, i) => ((i * s) % 251) - 125);
+
+    const drive = (sink: import("../host/sink.ts").StreamSink) => {
+      for (let s = 1; s <= 3; s++) sink.writeFrame(s * 2, paletteFor(s), pixelsFor(s));
+      for (let s = 1; s <= 2; s++) sink.writeAudio(s * 64, pcmFor(s));
+      sink.bumpEpoch();
+      sink.markEnded();
+    };
+
+    const filePath = `${tmp}/ref.pkst`;
+    const fileSink = new FileRingSink(tmp, "ref.pkst", GEO);
+    drive(fileSink);
+    const reference = new Uint8Array(readFileSync(filePath));
+
+    const tcpSink = conn!.makeSink("media/x.pkst", GEO);
+    drive(tcpSink);
+    // streamOpen + 3 slots + 2 chunks + 2 marks = 8 frames
+    await device.waitFrames(8);
+    const image = reassemble(device.frames);
+
+    expect(image.length).toBe(reference.length);
+    expect(Buffer.from(image).equals(Buffer.from(reference))).toBe(true);
+
+    device.close();
+    transport.close();
+  });
+});
+
+describe("wire encoders", () => {
+  test("the beacon datagram matches the spec layout", () => {
+    const beacon = encodeBeacon(8622, "youtube", "evanmac");
+    const dv = new DataView(beacon.buffer);
+    expect(dv.getUint32(0, true)).toBe(0x42444b50); // 'PKDB'
+    expect(dv.getUint8(4)).toBe(WIRE_VERSION);
+    expect(dv.getUint16(6, true)).toBe(8622);
+    expect(dv.getUint8(8)).toBe(7);
+    expect(new TextDecoder().decode(beacon.slice(9, 16))).toBe("youtube");
+    expect(dv.getUint8(16)).toBe(7);
+    expect(new TextDecoder().decode(beacon.slice(17))).toBe("evanmac");
+  });
+
+  test("geometry helpers agree with the header block", () => {
+    expect(slotSizeOf(GEO)).toBe((STREAM_SLOT_HEADER_SIZE + 1024 + GEO.w * GEO.h + 15) & ~15);
+    expect(chunkSizeOf(GEO)).toBe(16 + GEO.chunkFrames * GEO.channels * 2);
+    expect(STREAM_HEADER_BLOCK_SIZE).toBe(96);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,12 +8,14 @@
     "strict": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "types": ["bun-types"],
     "paths": {
-      "@pocketjs/framework": ["./vendor/pocketjs/src/index.ts"],
-      "@pocketjs/framework/solid": ["./vendor/pocketjs/src/index.ts"],
-      "@pocketjs/framework/input": ["./vendor/pocketjs/src/input-api.ts"],
-      "@pocketjs/framework/*": ["./vendor/pocketjs/src/*"]
+      "@pocketjs/framework": ["./vendor/pocketjs/framework/src/index.ts"],
+      "@pocketjs/framework/solid": ["./vendor/pocketjs/framework/src/index.ts"],
+      "@pocketjs/framework/input": ["./vendor/pocketjs/framework/src/input-api.ts"],
+      "@pocketjs/framework/*": ["./vendor/pocketjs/framework/src/*"],
+      "tools/cli/*": ["./vendor/pocketjs/tools/cli/*"]
     }
   },
   "include": ["app", "tools", "scripts"]


### PR DESCRIPTION
Part 1/2 of Vita support in pocket-youtube. Companion to pocketjs #168/#169 (the PKNT wire + the Vita host); the vendored pocketjs is pinned to that stack's tip and will be re-pinned to main once it merges upstream.

## What

- **Submodule migration** across the #149 restructure (spec→contracts/spec, src→framework/src, scripts→tools, native→hosts/psp, …) — app bundle, tests, and the PSP EBOOT all build/pass on the new pin.
- **TCP transport** (`host/transports/tcp.ts`, `host/wire.ts`, `host/discovery.ts`): PKNT frames over one ordered connection (FILE pushes before the results line, streamOpen before the announce line), `TcpStreamSink` with **latest-only video backpressure** (effective fps self-adapts to WiFi; audio always queues), per-slot PackBits when it shrinks, PKDB UDP beacon.
- **Device profiles** (`host/profiles.ts` + per-connection `TransportCtx`): `hello.device.target` picks the pipeline — PSP keeps 512×128@12/22.05k (mailbox output **byte-identical**, host tests untouched), Vita gets 512×256@24/44.1k. `media.ts` parameterized by sink geometry via the new `StreamSink` seam.
- **Proxy** (`host/proxy.ts`): `--proxy` > `HTTPS_PROXY` > `HTTP_PROXY`, threaded through yt-dlp / both ffmpeg pipelines (`-http_proxy` before `-i`) / thumbnail fetch. `.env.example` documents `http://127.0.0.1:7897`; `serve:vita` / `serve:proxy` scripts.

## Tests

`test/tcp.test.ts` (5): handshake + ctrl round-trip, wrong-app rejection, **FILE-before-results ordering**, beacon layout, and the **sink-equivalence proof** — one write sequence through `FileRingSink` vs `TcpStreamSink`+reassembler → byte-identical `.pkst` images (RLE + ring laps included). Plus: 12 host tests, 9 sim journeys, `tsc` clean, `bun run psp` EBOOT.

Next: PR 2/2 — the app side (VirtualList browse, touch player, vita target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)