### PR TITLE
fix(test): the sim always rebuilds the vendored wasm — close the stale-fact-path hole

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -41,10 +41,14 @@ export async function bootWorld(
   hz: number,
   extraGlobals?: Record<string, unknown>,
 ): Promise<SimWorld> {
-  if (!existsSync(WASM)) {
+  // ALWAYS rebuild: cargo's own caching makes a fresh build a ~2s no-op,
+  // and a stale pocketjs.wasm silently reroutes every touch journey through
+  // the ink-query fallback instead of the hit-fact path (the constant-33
+  // hardware bug shipped through exactly that hole).
+  {
     const p = Bun.spawnSync(["bun", "tools/wasm.ts"], {
       cwd: `${ROOT}vendor/pocketjs`,
-      stdout: "inherit",
+      stdout: "pipe",
       stderr: "inherit",
     });
     if (p.exitCode !== 0) throw new Error("harness: wasm build failed");


### PR DESCRIPTION
Companion to pocketjs#213 (the constant-33 hardware bug). Two changes:

- **vendor → 5dea701**: portal hosts are hit-transparent
- **harness always rebuilds `pocketjs.wasm`**: the build-only-if-missing check let a stale binary (predating op 42) reroute every touch journey through the ink-query fallback — the sim stayed green while real hardware ran a code path no rig had executed. Cargo caching makes the unconditional rebuild a ~2s no-op.

30/30 journeys now genuinely exercise the hit-fact path; the on-device diagnostic confirms per-position resolution (field=21, rows across slot generations) where the broken build reported one constant node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)