### PR TITLE
feat(host): density-2 HD cards — sharp list text on the Vita panel

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -263,29 +263,50 @@ function LoadMoreRow(props: { active: boolean; busy: boolean }) {
   );
 }
 
-/** One host-rendered full-width result row (512x64 texture, 456 visible —
- *  the pow2 tail is clipped by the wrapper). The texture loads through the
- *  driver's one-per-frame queue and is freed with the row. */
+/** One host-rendered full-width result row. Classic hosts: a single 512x64
+ *  texture (456 visible — the pow2 tail is clipped by the wrapper).
+ *  Density-2 hosts: the host sends the SAME card as two 512x128 halves
+ *  (TEX_MAX_DIM caps uploads at 512) drawn side by side at logical
+ *  half-width — 1:1 texels on a 2x panel, sharp text. Textures load through
+ *  the driver's one-per-frame queue and are freed with the row. */
 function ResultRow(props: { item: ResultItem; active: boolean }) {
+  const hd = props.item.cardHD;
   const [handle, setHandle] = createSignal(-1);
+  const [handleR, setHandleR] = createSignal(-1);
   let node: NodeMirror | undefined;
+  let nodeR: NodeMirror | undefined;
   let alive = true;
 
-  loadCard(props.item.card, (h) => {
+  loadCard(hd ? hd[0] : props.item.card, (h) => {
     if (!alive) {
       if (h >= 0) getOps().freeTexture?.(h);
       return;
     }
     setHandle(h);
   });
+  if (hd) {
+    loadCard(hd[1], (h) => {
+      if (!alive) {
+        if (h >= 0) getOps().freeTexture?.(h);
+        return;
+      }
+      setHandleR(h);
+    });
+  }
   onCleanup(() => {
     alive = false;
     const h = handle();
     if (h >= 0) getOps().freeTexture?.(h);
+    const hr = handleR();
+    if (hr >= 0) getOps().freeTexture?.(hr);
   });
   createEffect(() => {
     const h = handle();
     if (h >= 0 && node) getOps().setImage(node.id, h);
+  });
+  createEffect(() => {
+    const hr = handleR();
+    if (hr >= 0 && nodeR) getOps().setImage(nodeR.id, hr);
   });
 
   return (
@@ -300,15 +321,22 @@ function ResultRow(props: { item: ResultItem; active: boolean }) {
           </View>
         }
       >
-        {/* Absolute: an IN-FLOW 512-wide image gets flex-shrunk to the 456
+        {/* Absolute: an IN-FLOW wide image gets flex-shrunk to the 456
             wrapper (observed on hardware as an 11% squeeze — the baked
             corner arcs drifted ~50px into the row). Out of flow it renders
             1:1 and the wrapper's scissor clips the pow2 tail. */}
         <Image
           nodeRef={(n) => (node = n)}
           class="absolute"
-          style={{ insetT: 0, insetL: 0, width: 512, height: 64 }}
+          style={{ insetT: 0, insetL: 0, width: hd ? 256 : 512, height: 64 }}
         />
+        <Show when={hd && handleR() >= 0}>
+          <Image
+            nodeRef={(n) => (nodeR = n)}
+            class="absolute"
+            style={{ insetT: 0, insetL: 256, width: 256, height: 64 }}
+          />
+        </Show>
       </Show>
       <FocusRing active={props.active} />
     </View>

--- a/app/protocol.ts
+++ b/app/protocol.ts
@@ -27,6 +27,10 @@ export interface ResultItem {
   channel: string;
   durationS: number;
   views: number;
+  /** Density-2 halves (two 512x128 CLUT8 IMGs drawn side by side at
+   *  logical half-width — 1:1 texels on a 2x panel). Sent only to devices
+   *  whose hello negotiated a density-2 profile. */
+  cardHD?: [string, string];
   /** svc-relative IMG-entry path for loadImgFile (256x64 card). */
   card: string;
 }

--- a/app/store.ts
+++ b/app/store.ts
@@ -112,9 +112,16 @@ export function createYoutubeStore() {
     });
   };
 
+  /** Touch made accidental double-activation easy (two spawned host
+   *  pipelines observed on hardware) — one play request in flight at a time;
+   *  taps while resolving are absorbed. */
+  let playPending = false;
   const play = (item: ResultItem): void => {
+    if (playPending) return;
+    playPending = true;
     setStatus("RESOLVING…");
     runEffect<HostMsg>("yt/play", { videoId: item.videoId }, (msg) => {
+      playPending = false;
       if (msg.t === "playing") {
         setStatus("");
         setPlayer({

--- a/host/cards.ts
+++ b/host/cards.ts
@@ -233,6 +233,8 @@ export interface CardInput {
 /** Fill an axis-aligned rect with `color`, alpha-blending at `a`. */
 function fillRect(
   rgba: Uint8Array,
+  cw: number,
+  ch: number,
   x0: number,
   y0: number,
   w: number,
@@ -240,9 +242,9 @@ function fillRect(
   color: readonly number[],
   a = 1,
 ): void {
-  for (let y = Math.max(0, y0); y < Math.min(CARD_H, y0 + h); y++) {
-    for (let x = Math.max(0, x0); x < Math.min(CARD_W, x0 + w); x++) {
-      const o = (y * CARD_W + x) * 4;
+  for (let y = Math.max(0, y0); y < Math.min(ch, y0 + h); y++) {
+    for (let x = Math.max(0, x0); x < Math.min(cw, x0 + w); x++) {
+      const o = (y * cw + x) * 4;
       rgba[o] = rgba[o] + (color[0] - rgba[o]) * a;
       rgba[o + 1] = rgba[o + 1] + (color[1] - rgba[o + 1]) * a;
       rgba[o + 2] = rgba[o + 2] + (color[2] - rgba[o + 2]) * a;
@@ -251,55 +253,109 @@ function fillRect(
   }
 }
 
-/** Compose one 512x64 RGBA row (quantize + encodeImgT8 downstream): thumb +
- *  duration badge | title (1-2 lines), channel, views | chevron. */
-export async function renderCard(input: CardInput): Promise<Uint8Array> {
+/** Compose one (512x64)*s RGBA row (quantize + encodeImgT8 downstream):
+ *  thumb + duration badge | title (1-2 lines), channel, views | chevron.
+ *  Every coordinate and font size scales linearly; the card font is a real
+ *  vector font, so s=2 is a genuinely sharper rasterization, not an upscale.
+ *  s=1 reproduces the classic PSP card byte-for-byte. */
+async function composeCard(input: CardInput, s: number): Promise<Uint8Array> {
   await cardFont();
-  const rgba = new Uint8Array(CARD_W * CARD_H * 4);
-  for (let i = 0; i < CARD_W * CARD_H; i++) {
+  const W = CARD_W * s;
+  const H = CARD_H * s;
+  const rgba = new Uint8Array(W * H * 4);
+  for (let i = 0; i < W * H; i++) {
     rgba[i * 4] = BG[0];
     rgba[i * 4 + 1] = BG[1];
     rgba[i * 4 + 2] = BG[2];
     rgba[i * 4 + 3] = 255;
   }
-  if (input.thumbRgba && input.thumbRgba.length === THUMB_W * THUMB_H * 4) {
-    for (let y = 0; y < THUMB_H; y++) {
-      const src = input.thumbRgba.subarray(y * THUMB_W * 4, (y + 1) * THUMB_W * 4);
-      rgba.set(src, y * CARD_W * 4);
+  const tw2 = THUMB_W * s;
+  const th2 = THUMB_H * s;
+  if (input.thumbRgba && input.thumbRgba.length === tw2 * th2 * 4) {
+    for (let y = 0; y < th2; y++) {
+      const src = input.thumbRgba.subarray(y * tw2 * 4, (y + 1) * tw2 * 4);
+      rgba.set(src, y * W * 4);
     }
   } else {
     // Placeholder: a dimmer panel with a play glyph, so a failed thumbnail
     // fetch still reads as "a video".
-    fillRect(rgba, 0, 0, THUMB_W, THUMB_H, [0x1e, 0x2a, 0x38]);
-    drawText(rgba, CARD_W, CARD_H, "▶", (THUMB_W - textWidth("▶", 22)) / 2, 40, 22, DIM);
+    fillRect(rgba, W, H, 0, 0, tw2, th2, [0x1e, 0x2a, 0x38]);
+    drawText(rgba, W, H, "▶", (tw2 - textWidth("▶", 22 * s)) / 2, 40 * s, 22 * s, DIM);
   }
   // Duration badge on the thumbnail, bottom-right (the mockup chip).
   if (input.durationS > 0) {
     const label = fmtDuration(input.durationS);
-    const tw = Math.ceil(textWidth(label, 10));
-    const bx = THUMB_W - tw - 10;
-    fillRect(rgba, bx, THUMB_H - 16, tw + 8, 13, [0, 0, 0], 0.72);
-    drawText(rgba, CARD_W, CARD_H, label, bx + 4, THUMB_H - 6, 10, INK);
+    const tw = Math.ceil(textWidth(label, 10 * s));
+    const bx = tw2 - tw - 10 * s;
+    fillRect(rgba, W, H, bx, th2 - 16 * s, tw + 8 * s, 13 * s, [0, 0, 0], 0.72);
+    drawText(rgba, W, H, label, bx + 4 * s, th2 - 6 * s, 10 * s, INK);
   }
-  const tx = THUMB_W + 10;
-  const maxW = CARD_VISIBLE_W - tx - 26; // keep clear of the chevron
-  const lines = fitLines(input.title, 14, maxW, 2);
+  const tx = tw2 + 10 * s;
+  const maxW = CARD_VISIBLE_W * s - tx - 26 * s; // keep clear of the chevron
+  const lines = fitLines(input.title, 14 * s, maxW, 2);
   const views = input.views > 0 ? `${fmtViews(input.views)} views` : "";
   if (lines.length > 1) {
     // Two title lines: channel and views share the meta line.
-    drawText(rgba, CARD_W, CARD_H, lines[0], tx, 19, 14, INK);
-    drawText(rgba, CARD_W, CARD_H, lines[1], tx, 36, 14, INK);
+    drawText(rgba, W, H, lines[0], tx, 19 * s, 14 * s, INK);
+    drawText(rgba, W, H, lines[1], tx, 36 * s, 14 * s, INK);
     const meta = [input.channel, views].filter(Boolean).join(" · ");
-    drawText(rgba, CARD_W, CARD_H, fitLines(meta, 10, maxW, 1)[0] ?? "", tx, 55, 10, DIM);
+    drawText(rgba, W, H, fitLines(meta, 10 * s, maxW, 1)[0] ?? "", tx, 55 * s, 10 * s, DIM);
   } else {
     // The mockup layout: title / channel / views on their own lines.
-    drawText(rgba, CARD_W, CARD_H, lines[0] ?? "", tx, 21, 14, INK);
-    drawText(rgba, CARD_W, CARD_H, fitLines(input.channel, 10, maxW, 1)[0] ?? "", tx, 39, 10, DIM);
-    drawText(rgba, CARD_W, CARD_H, views, tx, 55, 10, DIM);
+    drawText(rgba, W, H, lines[0] ?? "", tx, 21 * s, 14 * s, INK);
+    drawText(rgba, W, H, fitLines(input.channel, 10 * s, maxW, 1)[0] ?? "", tx, 39 * s, 10 * s, DIM);
+    drawText(rgba, W, H, views, tx, 55 * s, 10 * s, DIM);
   }
-  drawText(rgba, CARD_W, CARD_H, "›", CARD_VISIBLE_W - 18, 39, 16, DIM);
-  roundCorners(rgba);
+  drawText(rgba, W, H, "›", (CARD_VISIBLE_W - 18) * s, 39 * s, 16 * s, DIM);
+  roundCorners(rgba, s);
   return rgba;
+}
+
+export function renderCard(input: CardInput): Promise<Uint8Array> {
+  return composeCard(input, 1);
+}
+
+/** Density-2 card: composed at 2x (1024x128) and split into two 512-wide
+ *  pow2 halves — TEX_MAX_DIM caps uploads at 512, so the app draws the pair
+ *  side by side at logical half-width for 1:1 texels on a density-2 panel. */
+export const CARD_HD_HALF_W = 512;
+export async function renderCardHD(
+  input: CardInput,
+): Promise<{ left: Uint8Array; right: Uint8Array }> {
+  const rgba = await composeCard(input, 2);
+  const w = CARD_W * 2;
+  const h = CARD_H * 2;
+  const half = (x0: number): Uint8Array => {
+    const out = new Uint8Array(CARD_HD_HALF_W * h * 4);
+    for (let y = 0; y < h; y++) {
+      out.set(
+        rgba.subarray((y * w + x0) * 4, (y * w + x0 + CARD_HD_HALF_W) * 4),
+        y * CARD_HD_HALF_W * 4,
+      );
+    }
+    return out;
+  };
+  return { left: half(0), right: half(CARD_HD_HALF_W) };
+}
+
+/** 2x2 box-average a 2x RGBA buffer down to 1x — the vita path fetches ONE
+ *  2x thumbnail and derives the classic 1x card from it. */
+export function downscale2(rgba: Uint8Array, w2: number, h2: number): Uint8Array {
+  const w = w2 >> 1;
+  const h = h2 >> 1;
+  const out = new Uint8Array(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      for (let c = 0; c < 4; c++) {
+        const a = rgba[((y * 2) * w2 + x * 2) * 4 + c];
+        const b = rgba[((y * 2) * w2 + x * 2 + 1) * 4 + c];
+        const d = rgba[((y * 2 + 1) * w2 + x * 2) * 4 + c];
+        const e = rgba[((y * 2 + 1) * w2 + x * 2 + 1) * 4 + c];
+        out[(y * w + x) * 4 + c] = (a + b + d + e + 2) >> 2;
+      }
+    }
+  }
+  return out;
 }
 
 /** App background behind the rows — corner masking must match it. */
@@ -314,20 +370,20 @@ const CORNER_R = 6;
  * background (antialiased against the true distance) is equivalent to a
  * rounded clip because rows always sit on that background.
  */
-function roundCorners(rgba: Uint8Array): void {
+function roundCorners(rgba: Uint8Array, s = 1): void {
   // Rounded-rect SDF over the visible area (pixel centers at +0.5): the
   // blend factor is the coverage OUTSIDE the pill, antialiased over 1px.
-  const hw = CARD_VISIBLE_W / 2 - CORNER_R;
-  const hh = CARD_H / 2 - CORNER_R;
-  for (let y = 0; y < CARD_H; y++) {
-    const qy = Math.abs(y + 0.5 - CARD_H / 2) - hh;
+  const hw = (CARD_VISIBLE_W * s) / 2 - CORNER_R * s;
+  const hh = (CARD_H * s) / 2 - CORNER_R * s;
+  for (let y = 0; y < CARD_H * s; y++) {
+    const qy = Math.abs(y + 0.5 - (CARD_H * s) / 2) - hh;
     if (qy <= 0) continue; // inside the vertical straight band — never clipped
-    for (let x = 0; x < CARD_VISIBLE_W; x++) {
-      const qx = Math.abs(x + 0.5 - CARD_VISIBLE_W / 2) - hw;
+    for (let x = 0; x < CARD_VISIBLE_W * s; x++) {
+      const qx = Math.abs(x + 0.5 - (CARD_VISIBLE_W * s) / 2) - hw;
       if (qx <= 0) continue;
-      const a = Math.min(1, Math.max(0, Math.hypot(qx, qy) - CORNER_R + 0.5));
+      const a = Math.min(1, Math.max(0, Math.hypot(qx, qy) - CORNER_R * s + 0.5));
       if (a <= 0) continue;
-      const o = (y * CARD_W + x) * 4;
+      const o = (y * CARD_W * s + x) * 4;
       rgba[o] = rgba[o] + (PAGE_BG[0] - rgba[o]) * a;
       rgba[o + 1] = rgba[o + 1] + (PAGE_BG[1] - rgba[o + 1]) * a;
       rgba[o + 2] = rgba[o + 2] + (PAGE_BG[2] - rgba[o + 2]) * a;
@@ -339,9 +395,13 @@ function roundCorners(rgba: Uint8Array): void {
 // Thumbnail fetch + decode (ffmpeg scale/crop; no freetype needed here)
 // ---------------------------------------------------------------------------
 
-/** Fetch a thumbnail and decode it to THUMB_W x THUMB_H RGBA via ffmpeg.
- *  Null on any failure — the card falls back to the placeholder panel. */
-export async function fetchThumbRGBA(url: string, tmpDir: string): Promise<Uint8Array | null> {
+/** Fetch a thumbnail and decode it to (THUMB_W x THUMB_H) * scale RGBA via
+ *  ffmpeg. Null on any failure — the card falls back to the placeholder. */
+export async function fetchThumbRGBA(
+  url: string,
+  tmpDir: string,
+  scale = 1,
+): Promise<Uint8Array | null> {
   try {
     const res = await fetch(url, {
       signal: AbortSignal.timeout(8000),
@@ -361,7 +421,7 @@ export async function fetchThumbRGBA(url: string, tmpDir: string): Promise<Uint8
         "-i",
         tmp,
         "-vf",
-        `scale=${THUMB_W}:${THUMB_H}:force_original_aspect_ratio=increase,crop=${THUMB_W}:${THUMB_H}`,
+        `scale=${THUMB_W * scale}:${THUMB_H * scale}:force_original_aspect_ratio=increase,crop=${THUMB_W * scale}:${THUMB_H * scale}`,
         "-frames:v",
         "1",
         "-f",
@@ -373,7 +433,7 @@ export async function fetchThumbRGBA(url: string, tmpDir: string): Promise<Uint8
       { stdout: "pipe", stderr: "ignore" },
     );
     const bytes = new Uint8Array(await new Response(proc.stdout).arrayBuffer());
-    if ((await proc.exited) !== 0 || bytes.length !== THUMB_W * THUMB_H * 4) return null;
+    if ((await proc.exited) !== 0 || bytes.length !== THUMB_W * THUMB_H * scale * scale * 4) return null;
     return bytes;
   } catch {
     return null;

--- a/host/serve.ts
+++ b/host/serve.ts
@@ -21,7 +21,17 @@ import { appendFileSync, existsSync, mkdirSync, statSync, writeFileSync } from "
 import { resolve as resolvePath } from "node:path";
 import { WIRE_PORT } from "../vendor/pocketjs/contracts/spec/spec.ts";
 import type { DeviceCmd, HostMsg, ResultItem } from "../app/protocol.ts";
-import { CARD_H, CARD_W, fetchThumbRGBA, renderCard } from "./cards.ts";
+import {
+  CARD_H,
+  CARD_HD_HALF_W,
+  CARD_W,
+  downscale2,
+  fetchThumbRGBA,
+  renderCard,
+  renderCardHD,
+  THUMB_H,
+  THUMB_W,
+} from "./cards.ts";
 import { startBeacon } from "./discovery.ts";
 import { encodeImgT8 } from "./img.ts";
 import { PlaySession } from "./media.ts";
@@ -127,21 +137,35 @@ async function renderItems(
   found: Awaited<ReturnType<typeof search>>,
   ctx: TransportCtx,
 ): Promise<ResultItem[]> {
+  // Density-2 devices get the card composed at 2x and split into two
+  // 512-wide pow2 halves (TEX_MAX_DIM); ONE 2x thumbnail fetch feeds both —
+  // the classic 1x card is derived by box-downscale. The PSP path below is
+  // untouched byte-for-byte.
+  const hd = ctx.profile.name === "vita";
   return Promise.all(
     found.map(async (f) => {
-      const thumb = await fetchThumbRGBA(thumbnailUrl(f.videoId), `${svcDir}/thumbs`);
-      const rgba = await renderCard({
+      const input = {
         title: f.title,
         channel: f.channel,
         durationS: f.durationS,
         views: f.views,
-        thumbRgba: thumb,
-      });
+      };
+      const thumb2 = hd ? await fetchThumbRGBA(thumbnailUrl(f.videoId), `${svcDir}/thumbs`, 2) : null;
+      const thumb = hd
+        ? thumb2 && downscale2(thumb2, THUMB_W * 2, THUMB_H * 2)
+        : await fetchThumbRGBA(thumbnailUrl(f.videoId), `${svcDir}/thumbs`);
+      const rgba = await renderCard({ ...input, thumbRgba: thumb });
       const rel = `thumbs/${f.videoId}.img`;
       // Delivered BEFORE the results line that references it (implicit on
       // the shared filesystem, explicit frame ordering on TCP).
       ctx.pushFile(rel, encodeImgT8(rgba, CARD_W, CARD_H));
-      return { ...f, card: rel };
+      if (!hd) return { ...f, card: rel };
+      const { left, right } = await renderCardHD({ ...input, thumbRgba: thumb2 });
+      const relL = `thumbs/${f.videoId}-hd-l.img`;
+      const relR = `thumbs/${f.videoId}-hd-r.img`;
+      ctx.pushFile(relL, encodeImgT8(left, CARD_HD_HALF_W, CARD_H * 2));
+      ctx.pushFile(relR, encodeImgT8(right, CARD_HD_HALF_W, CARD_H * 2));
+      return { ...f, card: rel, cardHD: [relL, relR] as [string, string] };
     }),
   );
 }

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -12,7 +12,18 @@ import { packbitsDecode, PSM } from "../vendor/pocketjs/contracts/spec/spec.ts";
 import { paletteBytes, quantize } from "../host/quant.ts";
 import { encodeImgT8 } from "../host/img.ts";
 import { readStream, StreamWriter, type StreamGeometry } from "../host/ring.ts";
-import { cardFont, CARD_H, CARD_VISIBLE_W, CARD_W, fitLines, fmtDuration, renderCard } from "../host/cards.ts";
+import {
+  cardFont,
+  CARD_H,
+  CARD_HD_HALF_W,
+  CARD_VISIBLE_W,
+  CARD_W,
+  downscale2,
+  fitLines,
+  fmtDuration,
+  renderCard,
+  renderCardHD,
+} from "../host/cards.ts";
 import { search, resolve as resolveVideo, type Runner } from "../host/yt.ts";
 
 const tmp = mkdtempSync(join(tmpdir(), "pocket-youtube-"));
@@ -238,6 +249,39 @@ describe("cards", () => {
       expect(card[(y * CARD_W + x) * 4]).toBe(0x0b);
     }
     expect(card[(30 * CARD_W + 0) * 4 + 2]).toBe(160); // mid-left edge: thumb intact
+  });
+
+  test("renderCardHD: two seamless 512-wide halves at true 2x sharpness", async () => {
+    const { left, right } = await renderCardHD({
+      title: "Vue Vapor on a PSP — the longest title we render wraps to two lines",
+      channel: "pocket-stack",
+      durationS: 754,
+      views: 123456,
+      thumbRgba: solid(232, 128, 40, 80, 160),
+    });
+    const H2 = CARD_H * 2;
+    expect(left.length).toBe(CARD_HD_HALF_W * H2 * 4);
+    expect(right.length).toBe(CARD_HD_HALF_W * H2 * 4);
+    // The 2x thumbnail pixel lands in the left half.
+    expect(left[(20 * CARD_HD_HALF_W + 20) * 4 + 2]).toBe(160);
+    // The title band crosses the x=512 seam (text spans 252..~860 physical):
+    // the right half must carry ink in its leftmost columns — a broken split
+    // would show background there.
+    let seamInk = 0;
+    for (let y = 20; y < 60; y++) {
+      for (let x = 0; x < 40; x++) {
+        if (right[(y * CARD_HD_HALF_W + x) * 4] > 0x30) seamInk++;
+      }
+    }
+    expect(seamInk).toBeGreaterThan(0);
+  });
+
+  test("downscale2 box-averages a 2x buffer to 1x", () => {
+    const two = solid(4, 4, 100, 200, 40);
+    const one = downscale2(two, 4, 4);
+    expect(one.length).toBe(2 * 2 * 4);
+    expect(one[0]).toBe(100);
+    expect(one[1]).toBe(200);
   });
 
   test("fmtDuration covers m:ss and h:mm:ss", () => {


### PR DESCRIPTION
The acceptance-day report: the list works, but its text is blurry — cards are host-composited **1x bitmaps upscaled 2x** on the 960×544 panel (framework text was always native-density sharp).

## What changes

- The card composer takes an integer scale; the card font is a **vector font**, so 2x is a true sharper rasterization (s=1 stays byte-for-byte the classic PSP card)
- Density-2 profiles compose at **1024×128** and split into **two 512-wide pow2 halves** (`TEX_MAX_DIM`), pushed before the results line; `ResultItem.cardHD` names the pair
- The app draws the pair side by side at logical half-width → **1:1 texels**; one 2x thumbnail fetch feeds both renditions (1x derives by box-downscale); PSP path untouched
- Rider fix: **one play request in flight** — touch made double-activation easy (two host pipelines for one videoId observed on hardware)

31/31 tests (seam-continuity + downscale cases new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)